### PR TITLE
I've refactored your frontend API calls to use specific services.

### DIFF
--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -1,7 +1,8 @@
 import React, { useEffect, useState } from 'react';
 import { Link } from 'react-router-dom';
 import { useAuthStore } from '../store/authStore';
-import { DefaultService, type ExpenseRead } from '../generated/api'; // Assuming ExpenseRead is the correct type
+import { ExpensesService } from '../generated/api';
+import { type ExpenseRead } from '../generated/api'; // Assuming ExpenseRead is the correct type
 import { PlusCircleIcon, UserGroupIcon, DocumentTextIcon, ArrowRightIcon } from '@heroicons/react/24/outline'; // Example icons
 
 const DashboardPage: React.FC = () => {
@@ -34,7 +35,7 @@ const DashboardPage: React.FC = () => {
           // or it returns all expenses accessible to the user.
           // The schema shows `user_id: number (Query)` for `read_expenses_api_v1_expenses_get`.
           // This suggests it's for filtering expenses *related* to the user.
-          const response = await DefaultService.readExpensesApiV1ExpensesGet({ userId: user.id });
+          const response = await ExpensesService.readExpensesEndpointApiV1ExpensesGet(undefined, 100, user.id); // skip, limit, userId
           setExpenses(response);
 
           // Calculate summaries

--- a/frontend/src/pages/ExpensesPage.tsx
+++ b/frontend/src/pages/ExpensesPage.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState, useMemo } from 'react';
 import { Link } from 'react-router-dom';
-import { DefaultService, type ExpenseRead, type UserRead } from '../generated/api';
+import { ExpensesService, UsersService } from '../generated/api';
+import { type ExpenseRead, type UserRead } from '../generated/api';
 import { useAuthStore } from '../store/authStore';
 import { PlusCircleIcon, DocumentTextIcon, UserGroupIcon, ChevronRightIcon, CalendarDaysIcon, UserCircleIcon } from '@heroicons/react/24/outline';
 
@@ -25,7 +26,8 @@ const ExpenseListPage: React.FC = () => {
       setError(null);
       try {
         // Fetch expenses where the user is involved
-        const fetchedExpenses = await DefaultService.readExpensesApiV1ExpensesGet({ userId: currentUser.id });
+        // Parameters for readExpensesEndpointApiV1ExpensesGet: skip?: number, limit?: number, userId?: number | null, groupId?: number | null
+        const fetchedExpenses = await ExpensesService.readExpensesEndpointApiV1ExpensesGet(undefined, undefined, currentUser.id, undefined);
         setExpenses(fetchedExpenses.sort((a, b) => new Date(b.date).getTime() - new Date(a.date).getTime())); // Sort by date descending
 
         // Collect all unique user IDs from expenses (payers and participants) to fetch their details if needed
@@ -41,7 +43,8 @@ const ExpenseListPage: React.FC = () => {
           // This could be inefficient if there are many users.
           // A better approach would be a dedicated endpoint like /api/v1/users/batch?ids=1,2,3
           try {
-            const allUsers = await DefaultService.readUsersApiV1UsersGet({}); // Fetch all users
+            // Parameters for readUsersEndpointApiV1UsersGet: skip?: number, limit?: number
+            const allUsers = await UsersService.readUsersEndpointApiV1UsersGet(undefined, undefined); // Fetch all users (or default limit)
             const map: Record<number, UserRead> = {};
             allUsers.forEach(u => { map[u.id] = u; });
             setUsersMap(map);

--- a/frontend/src/pages/GroupsPage.tsx
+++ b/frontend/src/pages/GroupsPage.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import { Link } from 'react-router-dom';
-import { DefaultService, type GroupRead } from '../generated/api'; // Assuming GroupRead is the correct type
+import { GroupsService } from '../generated/api';
+import { type GroupRead } from '../generated/api'; // Assuming GroupRead is the correct type
 import { PlusCircleIcon, UserGroupIcon, ChevronRightIcon } from '@heroicons/react/24/outline';
 import { useAuthStore } from '../store/authStore';
 
@@ -16,8 +17,9 @@ const GroupsPage: React.FC = () => {
         setLoading(true);
         setError(null);
         try {
-          // Assuming readGroupsApiV1GroupsGet fetches groups for the authenticated user
-          const response = await DefaultService.readGroupsApiV1GroupsGet({}); // Empty object if no params needed
+          // Assuming readGroupsEndpointApiV1GroupsGet fetches groups for the authenticated user
+          // It takes optional skip and limit parameters. Calling with no arguments fetches with defaults (e.g., limit 100).
+          const response = await GroupsService.readGroupsEndpointApiV1GroupsGet();
           setGroups(response);
         } catch (err: any) {
           setError(err.message || 'Failed to fetch groups.');

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from 'react'; // Added useEffect
 import { useNavigate, useLocation } from 'react-router-dom'; // Added useLocation
-import { DefaultService, type Body_login_for_access_token_api_v1_users_token_post, OpenAPI } from '../generated/api';
+import { UsersService, OpenAPI } from '../generated/api';
+import { type Body_login_for_access_token_api_v1_users_token_post, type Token, type UserRead } from '../generated/api'; // Assuming Token and UserRead are relevant
 import { useAuthStore } from '../store/authStore';
 
 const LoginPage: React.FC = () => {
@@ -58,14 +59,14 @@ const LoginPage: React.FC = () => {
       loginData.append('password', password);
 
 
-      const tokenResponse = await DefaultService.loginForAccessTokenApiV1UsersTokenPost(loginData);
+      const tokenResponse: Token = await UsersService.loginForAccessTokenApiV1UsersTokenPost(loginData);
       const token = tokenResponse.access_token;
 
       // Configure API client to use this token for subsequent requests
       OpenAPI.TOKEN = token; // Set token for future requests
 
       // Fetch the current user's details
-      const user = await DefaultService.readCurrentUserApiV1UsersMeGet();
+      const user: UserRead = await UsersService.readUserMeApiV1UsersMeGet();
 
       // Store the token and user details
       setToken(token, user);


### PR DESCRIPTION
This addresses the issue of using a generic `DefaultService` for API calls throughout the frontend. I also standardized the import syntax for API models.

Here's what I did:
- I replaced `DefaultService` with specific services (`ExpensesService`, `GroupsService`, `UsersService`) in the following files:
  - `frontend/src/pages/DashboardPage.tsx`
  - `frontend/src/pages/ExpensesPage.tsx`
  - `frontend/src/pages/GroupsPage.tsx`
  - `frontend/src/pages/LoginPage.tsx`
- I updated API model imports in these files to use the `import {type X} from "..."` syntax.
- I verified and corrected input parameters for API calls in the modified files to align with the actual service definitions.
- I identified other files that still require refactoring from `DefaultService`.

Further work is needed to refactor the remaining pages and components, update `authStore.ts`, and remove the `DefaultService` from the generated API client.