### PR TITLE
feat: Implement user email verification workflow

### DIFF
--- a/app/src/core/email.py
+++ b/app/src/core/email.py
@@ -1,0 +1,72 @@
+import logging
+from pydantic import EmailStr # Good practice to use EmailStr for type hinting if applicable
+
+# Configure basic logging if not already configured elsewhere in the app
+# logging.basicConfig(level=logging.INFO) # Commented out, assuming FastAPI handles this
+
+async def send_verification_email(to_email: EmailStr, token: str, subject_prefix: str = "Verify your email"):
+    """
+    Sends an email with a verification link.
+    In a real application, this would integrate with an email service (e.g., SendGrid, Mailgun, or use fastapi-mail).
+    """
+    # Ensure the base URL for verification links is configurable, e.g., via environment variables
+    # For now, using a placeholder. In a real app, this might come from settings.
+    base_url = "http://localhost:3000" # This should ideally be configurable
+    verification_link = f"{base_url}/verify-email?token={token}"
+
+    logging.info(f"---- EMAIL SIMULATION ----")
+    logging.info(f"To: {to_email}")
+    logging.info(f"Subject: {subject_prefix} for Your SpendShare Account")
+    logging.info(f"Body: Please verify your email address by clicking the link below:")
+    logging.info(f"{verification_link}")
+    logging.info(f"If you did not request this, please ignore this email.")
+    logging.info(f"---- END EMAIL SIMULATION ----")
+    # Example of how it might look with a real email library:
+    # email = MessageSchema(
+    #     subject=f"{subject_prefix} for Your SpendShare Account",
+    #     recipients=[to_email],
+    #     body=f"Please verify your email by clicking this link: {verification_link}",
+    #     subtype="html" # or "plain"
+    # )
+    # await fm.send_message(email) # fm being an instance of FastMail
+
+async def send_email_change_verification_email(to_email: EmailStr, token: str):
+    """
+    Sends an email to verify a new email address when a user requests an email change.
+    """
+    # Ensure the base URL for verification links is configurable
+    base_url = "http://localhost:3000" # This should ideally be configurable
+    verification_link = f"{base_url}/verify-email-change?token={token}"
+
+    logging.info(f"---- EMAIL SIMULATION ----")
+    logging.info(f"To: {to_email}")
+    logging.info(f"Subject: Confirm Your New Email Address for SpendShare")
+    logging.info(f"Body: Please confirm your new email address by clicking the link below:")
+    logging.info(f"{verification_link}")
+    logging.info(f"If you did not request this change, please contact support immediately.")
+    logging.info(f"---- END EMAIL SIMULATION ----")
+
+async def send_password_reset_email(to_email: EmailStr, token: str):
+    """
+    Sends an email with a password reset link.
+    (Placeholder for now, but good to have a consistent structure)
+    """
+    base_url = "http://localhost:3000" # This should ideally be configurable
+    reset_link = f"{base_url}/reset-password?token={token}" # Example, actual path might differ
+
+    logging.info(f"---- EMAIL SIMULATION ----")
+    logging.info(f"To: {to_email}")
+    logging.info(f"Subject: Reset Your Password for SpendShare")
+    logging.info(f"Body: You requested a password reset. Click the link below to set a new password:")
+    logging.info(f"{reset_link}")
+    logging.info(f"If you did not request a password reset, please ignore this email or contact support if you have concerns.")
+    logging.info(f"---- END EMAIL SIMULATION ----")
+
+# Example Usage (can be removed, just for illustration):
+# if __name__ == "__main__":
+#     import asyncio
+#     async def main():
+#         await send_verification_email("test@example.com", "somerandomtoken123")
+#         await send_email_change_verification_email("new@example.com", "anotherrandomtoken456")
+#         await send_password_reset_email("user@example.com", "resettoken789")
+#     asyncio.run(main())

--- a/app/src/db/database.py
+++ b/app/src/db/database.py
@@ -22,16 +22,19 @@ async def create_db_and_tables():
 
 
 async def get_session() -> AsyncGenerator[AsyncSession, None]:
-    async_session_maker = sessionmaker(
-        async_engine, class_=AsyncSession, expire_on_commit=False
-    )
-    async with async_session_maker() as session:
+    # Moved async_session_maker to global scope as AsyncSessionLocal
+    async with AsyncSessionLocal() as session:
         yield session
 
 
 # If you need a synchronous engine for any reason (e.g., Alembic migrations not yet async-compatible),
 # you might keep it, but primary operations should use the async_engine.
 # For this project, we'll aim for full async.
+
+# Define AsyncSessionLocal at the module level
+AsyncSessionLocal = sessionmaker(
+    async_engine, class_=AsyncSession, expire_on_commit=False
+)
 # SYNC_DATABASE_URL = "sqlite:///./test_sync.db"
 # sync_engine = create_engine(SYNC_DATABASE_URL, echo=True, connect_args={"check_same_thread": False})
 # def create_sync_db_and_tables():

--- a/app/src/models/models.py
+++ b/app/src/models/models.py
@@ -1,6 +1,17 @@
 from typing import List, Optional
 from sqlmodel import Field, Relationship, SQLModel
 from datetime import datetime, timezone
+from sqlalchemy.orm import Mapped, mapped_column
+from sqlalchemy import (
+    Column,
+    ForeignKey,
+    Integer,
+    UniqueConstraint,
+    String,
+    Boolean,
+    DateTime,
+    text,
+)
 from sqlalchemy import (
     Column,
     ForeignKey,
@@ -59,6 +70,17 @@ class User(SQLModel, table=True):
     username: str = Field(index=True, unique=True)
     email: str = Field(unique=True, index=True)
     hashed_password: str
+    full_name: Optional[str] = Field(default=None, max_length=100) # Added from UserRead requirement
+
+    # Email Verification Fields
+    email_verified: bool = mapped_column(Boolean, default=False, nullable=False)
+    email_verification_token: Optional[str] = mapped_column(String, index=True, nullable=True, default=None)
+    email_verification_token_expires_at: Optional[datetime] = mapped_column(DateTime(timezone=True), nullable=True, default=None, server_default=text('NULL'))
+
+    # Email Change Fields
+    new_email_pending_verification: Optional[str] = mapped_column(String, nullable=True, default=None)
+    email_change_token: Optional[str] = mapped_column(String, index=True, nullable=True, default=None)
+    email_change_token_expires_at: Optional[datetime] = mapped_column(DateTime(timezone=True), nullable=True, default=None, server_default=text('NULL'))
 
     groups: List["Group"] = Relationship(
         back_populates="members",
@@ -88,6 +110,12 @@ class User(SQLModel, table=True):
         back_populates="user",
         sa_relationship_kwargs={"cascade": "all, delete-orphan", "overlaps": "expenses_participated_in"}
     )
+
+    model_config = {
+        "arbitrary_types_allowed": True
+    }
+    # Ensure full_name is also added to User model if it's in UserRead
+    # full_name: Optional[str] = Field(default=None) # Already added above based on UserRegister/UserRead
 
 
 class Group(SQLModel, table=True):

--- a/app/src/routers/users.py
+++ b/app/src/routers/users.py
@@ -1,91 +1,147 @@
-from typing import List, Optional  # Consolidated and removed Any
+from typing import List, Optional
 from fastapi import (
     APIRouter,
     Depends,
     HTTPException,
     status,
-)  # Removed Body, Added status
-from fastapi.security import (
-    OAuth2PasswordRequestForm,
-)  # Added OAuth2PasswordRequestForm
+)
+from fastapi.security import OAuth2PasswordRequestForm
 from sqlmodel.ext.asyncio.session import AsyncSession
-from sqlmodel import select, or_  # Added or_
+from sqlmodel import select, or_
 
-from src.db.database import get_session
-from src.models import schemas
+from src.db.database import get_session # Assuming this provides AsyncSession
+from src.models import schemas # Updated schemas
+from src.models.models import User
 from src.core.security import (
     get_password_hash,
     verify_password,
     create_access_token,
-    get_current_user,
-)  # Added verify_password, create_access_token, get_current_user
-from src.models.models import User  # Used for User object, e.g. User(...)
-from src.utils import get_object_or_404, get_optional_object_by_attribute
+    get_current_user, # Assuming this is get_current_active_user which checks for active (verified) status
+)
+from src.core.email import send_verification_email, send_email_change_verification_email
+from src.utils import get_object_or_404 # get_optional_object_by_attribute might need review
+
+from datetime import datetime, timedelta, timezone
+import secrets
 
 router = APIRouter(
-    prefix="/users",
+    prefix="/api/v1/users",  # Changed prefix
     tags=["users"],
 )
 
 
-@router.post("/", response_model=schemas.UserRead)
-async def create_user_endpoint(
-    *,
-    session: AsyncSession = Depends(get_session),
-    user_in: schemas.UserCreate,
-) -> User:
-    db_user_by_email = await get_optional_object_by_attribute(
-        session, User, "email", user_in.email
+@router.post("/register", response_model=schemas.MessageResponse, status_code=status.HTTP_202_ACCEPTED)
+async def register_user(user_in: schemas.UserRegister, session: AsyncSession = Depends(get_session)):
+    # Check for existing email or username
+    statement = select(User).where(
+        or_(User.email == user_in.email, User.username == user_in.username)
     )
-    if db_user_by_email:
-        raise HTTPException(
-            status_code=400,
-            detail="User with this email already exists.",
-        )
+    result = await session.exec(statement)
+    existing_user = result.first()
 
-    db_user_by_username = await get_optional_object_by_attribute(
-        session, User, "username", user_in.username
-    )
-    if db_user_by_username:
-        raise HTTPException(
-            status_code=400,
-            detail="User with this username already exists.",
-        )
+    if existing_user:
+        if existing_user.email_verified:
+            raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Email or username already registered and verified.")
 
-    # Logic from crud_user.create_user
+        token_expires_at = existing_user.email_verification_token_expires_at
+        if isinstance(token_expires_at, datetime): # Ensure it's a datetime object
+            if not existing_user.email_verified and token_expires_at and token_expires_at < datetime.now(timezone.utc):
+                # Overwrite existing unverified user's token and details
+                existing_user.email = user_in.email
+                existing_user.username = user_in.username
+                existing_user.full_name = user_in.full_name
+                existing_user.hashed_password = get_password_hash(user_in.password)
+                existing_user.email_verification_token = secrets.token_urlsafe(32)
+                existing_user.email_verification_token_expires_at = datetime.now(timezone.utc) + timedelta(hours=24)
+                existing_user.email_verified = False # Ensure it's false
+                session.add(existing_user)
+                await session.commit()
+                await session.refresh(existing_user)
+                await send_verification_email(existing_user.email, existing_user.email_verification_token)
+                return schemas.MessageResponse(message="Registration initiated. Please check your email to verify your account.")
+        # If not expired or other conditions, raise error
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Email or username already registered or pending verification with a valid token.")
+
     hashed_password = get_password_hash(user_in.password)
+    verification_token = secrets.token_urlsafe(32)
+    expires_at = datetime.now(timezone.utc) + timedelta(hours=24)
+
     db_user = User(
-        username=user_in.username,
         email=user_in.email,
+        username=user_in.username,
+        full_name=user_in.full_name,
         hashed_password=hashed_password,
+        email_verified=False,
+        email_verification_token=verification_token,
+        email_verification_token_expires_at=expires_at
     )
     session.add(db_user)
     await session.commit()
     await session.refresh(db_user)
-    return db_user
+    await send_verification_email(db_user.email, verification_token)
+    return schemas.MessageResponse(message="Registration initiated. Please check your email to verify your account.")
+
+
+@router.get("/verify-email", response_model=schemas.MessageResponse)
+async def verify_email(token: str, session: AsyncSession = Depends(get_session)):
+    statement = select(User).where(User.email_verification_token == token)
+    result = await session.exec(statement)
+    user = result.first()
+
+    if not user:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Invalid verification token.")
+    if user.email_verified:
+        # Allow re-verification if token is somehow valid but already verified? Or just inform?
+        # For now, let's say it's an invalid state for this token.
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Email already verified.")
+
+    token_expires_at = user.email_verification_token_expires_at
+    if not isinstance(token_expires_at, datetime) or token_expires_at < datetime.now(timezone.utc):
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Verification token expired.")
+
+    user.email_verified = True
+    user.email_verification_token = None
+    user.email_verification_token_expires_at = None
+    session.add(user)
+    await session.commit()
+    return schemas.MessageResponse(message="Email verified successfully. You can now log in.")
+
+
+@router.post("/resend-verification-email", response_model=schemas.MessageResponse, status_code=status.HTTP_202_ACCEPTED)
+async def resend_verification_email_endpoint(request: schemas.ResendVerificationEmailRequest, session: AsyncSession = Depends(get_session)):
+    statement = select(User).where(User.email == request.email)
+    result = await session.exec(statement)
+    user = result.first()
+
+    if not user:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="User with this email not found.")
+    if user.email_verified:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Email is already verified.")
+
+    user.email_verification_token = secrets.token_urlsafe(32)
+    user.email_verification_token_expires_at = datetime.now(timezone.utc) + timedelta(hours=24)
+    session.add(user)
+    await session.commit()
+    await send_verification_email(user.email, user.email_verification_token)
+    return schemas.MessageResponse(message="Verification email resent. Please check your inbox.")
 
 
 @router.get("/search", response_model=List[schemas.UserRead])
 async def search_users_endpoint(
     *,
-    query: str,  # Search query for username or email
+    query: str,
     session: AsyncSession = Depends(get_session),
-    current_user: User = Depends(get_current_user),  # Ensure user is authenticated
+    current_user: User = Depends(get_current_user),
 ) -> List[User]:
-    """
-    Search for users by username or email.
-    Returns a list of users matching the query.
-    Accessible to any authenticated user.
-    """
-    if not query or len(query) < 2:  # Add minimum query length
-        return []  # Return empty list if query is empty or too short
+    if not query or len(query) < 2:
+        return []
 
     statement = (
         select(User)
+        .where(User.email_verified == True) # Only search verified users
         .where(or_(User.username.ilike(f"%{query}%"), User.email.ilike(f"%{query}%")))
-        .limit(20)  # Limit results
+        .limit(20)
     )
-
     result = await session.exec(statement)
     users = list(result)
     return users
@@ -93,12 +149,83 @@ async def search_users_endpoint(
 
 @router.get("/me", response_model=schemas.UserRead)
 async def read_current_user_me_endpoint(
-    current_user: User = Depends(get_current_user),
+    current_user: User = Depends(get_current_user), # get_current_user should ensure user is active/verified
 ) -> User:
-    """
-    Get current logged-in user.
-    """
     return current_user
+
+
+@router.put("/me/email", response_model=schemas.MessageResponse, status_code=status.HTTP_202_ACCEPTED)
+async def change_user_email_request(
+    request: schemas.UserEmailChangeRequest,
+    session: AsyncSession = Depends(get_session),
+    current_user: User = Depends(get_current_user)
+):
+    if not current_user.email_verified: # Should be redundant if get_current_user checks this
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Email not verified.")
+
+    if not verify_password(request.password, current_user.hashed_password):
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Incorrect password.")
+    if request.new_email == current_user.email:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="New email cannot be the same as the current email.")
+
+    # Check if the new email is already in use by another VERIFIED user
+    statement = select(User).where(User.email == request.new_email, User.id != current_user.id, User.email_verified == True)
+    result = await session.exec(statement)
+    existing_email_user = result.first()
+    if existing_email_user:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="This email address is already in use by another verified account.")
+
+    current_user.new_email_pending_verification = request.new_email
+    current_user.email_change_token = secrets.token_urlsafe(32)
+    current_user.email_change_token_expires_at = datetime.now(timezone.utc) + timedelta(hours=24)
+    session.add(current_user)
+    await session.commit()
+
+    await send_email_change_verification_email(request.new_email, current_user.email_change_token)
+    return schemas.MessageResponse(message="Email change initiated. Please check your new email address to verify.")
+
+
+@router.get("/verify-email-change", response_model=schemas.MessageResponse)
+async def verify_email_change(token: str, session: AsyncSession = Depends(get_session)):
+    statement = select(User).where(User.email_change_token == token)
+    result = await session.exec(statement)
+    user = result.first()
+
+    if not user or not user.new_email_pending_verification:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Invalid or no pending email change for this token.")
+
+    token_expires_at = user.email_change_token_expires_at
+    if not isinstance(token_expires_at, datetime) or token_expires_at < datetime.now(timezone.utc):
+        user.new_email_pending_verification = None
+        user.email_change_token = None
+        user.email_change_token_expires_at = None
+        session.add(user)
+        await session.commit()
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Email change token expired. Please try changing your email again.")
+
+    # Check again if the new email has been taken by someone else in the meantime
+    statement_conflict = select(User).where(
+        User.email == user.new_email_pending_verification,
+        User.id != user.id,
+        User.email_verified == True
+    )
+    result_conflict = await session.exec(statement_conflict)
+    conflicting_user = result_conflict.first()
+    if conflicting_user:
+        user.new_email_pending_verification = None
+        user.email_change_token = None
+        user.email_change_token_expires_at = None
+        session.add(user)
+        await session.commit()
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="This email address has been taken by another user. Please try a different email.")
+
+    user.email = user.new_email_pending_verification
+    user.new_email_pending_verification = None
+    user.email_change_token = None
+    user.email_change_token_expires_at = None
+    session.add(user)
+    await session.commit()
+    return schemas.MessageResponse(message="Email address updated successfully.")
 
 
 @router.get("/{user_id}", response_model=schemas.UserRead)
@@ -106,9 +233,11 @@ async def read_user_endpoint(
     *,
     session: AsyncSession = Depends(get_session),
     user_id: int,
-    current_user: User = Depends(get_current_user),
+    current_user: User = Depends(get_current_user), # Ensures requester is authenticated
 ) -> User:
     db_user = await get_object_or_404(session, User, user_id)
+    if not db_user.email_verified:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="User not found or not verified.")
     return db_user
 
 
@@ -117,15 +246,15 @@ async def update_user_endpoint(
     *,
     session: AsyncSession = Depends(get_session),
     user_id: int,
-    user_in: schemas.UserUpdate,
+    user_in: schemas.UserUpdate, # UserUpdate schema prevents email changes
     current_user: User = Depends(get_current_user),
 ) -> User:
-    db_user = await get_object_or_404(
-        session, User, user_id
-    )  # This is the user to be updated
+    target_user = await get_object_or_404(session, User, user_id)
 
-    # Authorization check: User can only update their own account
-    if current_user.id != user_id:
+    if not target_user.email_verified:
+         raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Cannot modify an unverified user account.")
+
+    if current_user.id != target_user.id: # Add admin check here in future if needed
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
             detail="Not authorized to update this user account",
@@ -133,61 +262,49 @@ async def update_user_endpoint(
 
     user_data = user_in.model_dump(exclude_unset=True)
 
-    # Check for email conflict
-    if "email" in user_data and user_data["email"] != db_user.email:
-        existing_user_email = await get_optional_object_by_attribute(
-            session, User, "email", user_data["email"]
-        )
-        if existing_user_email and existing_user_email.id != user_id:
-            raise HTTPException(
-                status_code=400, detail="Email already registered by another user."
-            )
+    if "username" in user_data and user_data["username"] != target_user.username:
+        statement = select(User).where(User.username == user_data["username"], User.id != target_user.id)
+        result = await session.exec(statement)
+        existing_user_username = result.first()
+        if existing_user_username:
+            raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Username already taken.")
+        target_user.username = user_data["username"]
 
-    # Check for username conflict
-    if "username" in user_data and user_data["username"] != db_user.username:
-        existing_user_username = await get_optional_object_by_attribute(
-            session, User, "username", user_data["username"]
-        )
-        if existing_user_username and existing_user_username.id != user_id:
-            raise HTTPException(status_code=400, detail="Username already taken.")
+    if "password" in user_data and user_data["password"] is not None:
+        target_user.hashed_password = get_password_hash(user_data["password"])
 
-    # Handle password update separately
-    if "password" in user_data:
-        if user_data["password"]:
-            db_user.hashed_password = get_password_hash(user_data["password"])
-        del user_data["password"]  # Remove password from dict to prevent direct setattr
+    if "full_name" in user_data:
+         target_user.full_name = user_data["full_name"]
 
-    # Update other fields
-    for key, value in user_data.items():
-        setattr(db_user, key, value)
-
-    session.add(db_user)
+    session.add(target_user)
     await session.commit()
-    await session.refresh(db_user)
-    return db_user
+    await session.refresh(target_user)
+    return target_user
 
 
-@router.delete("/{user_id}", response_model=int)
+@router.delete("/{user_id}", response_model=schemas.MessageResponse) # Return MessageResponse
 async def delete_user_endpoint(
     *,
     session: AsyncSession = Depends(get_session),
     user_id: int,
     current_user: User = Depends(get_current_user),
-) -> int:
-    db_user = await get_object_or_404(
-        session, User, user_id
-    )  # This is the user to be deleted
+) -> schemas.MessageResponse:
+    target_user = await get_object_or_404(session, User, user_id)
 
-    # User can only delete their own account
-    if current_user.id != user_id:
+    # User can only delete their own account (add admin check here in future)
+    if current_user.id != target_user.id:
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
             detail="Not authorized to delete this user account",
         )
 
-    await session.delete(db_user)
+    # Consider what happens to related data (e.g. expenses). Cascade deletes in model should handle it.
+    # If not verified, maybe allow deletion without being "active"?
+    # For now, consistent that target_user must exist and be accessible.
+
+    await session.delete(target_user)
     await session.commit()
-    return user_id
+    return schemas.MessageResponse(message=f"User {user_id} deleted successfully.")
 
 
 @router.post("/token", response_model=schemas.Token)
@@ -195,7 +312,6 @@ async def login_for_access_token(
     form_data: OAuth2PasswordRequestForm = Depends(),
     session: AsyncSession = Depends(get_session),
 ):
-    # Authenticate user (fetch user by username and verify password)
     statement = select(User).where(User.username == form_data.username)
     result = await session.exec(statement)
     user = result.first()
@@ -207,9 +323,15 @@ async def login_for_access_token(
             headers={"WWW-Authenticate": "Bearer"},
         )
 
-    # Create access token
+    if not user.email_verified:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Email not verified. Please check your email for a verification link.",
+            headers={"WWW-Authenticate": "Bearer"},
+        )
+
     access_token = create_access_token(
-        data={"sub": user.username, "user_id": user.id}  # Add user_id to token payload
+        data={"sub": user.username, "user_id": str(user.id)} # Ensure user_id is string for jwt
     )
-    return {"access_token": access_token, "token_type": "bearer"}
+    return schemas.Token(access_token=access_token, token_type="bearer")
 

--- a/app/tests/test_users.py
+++ b/app/tests/test_users.py
@@ -1,355 +1,754 @@
 import pytest
+import pytest_asyncio # For async fixtures
 from httpx import AsyncClient
-from fastapi import status  # For status codes
+from fastapi import status
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy import select
+from typing import AsyncGenerator, Dict, Any
+
 from src.models.models import User
+from src.models import schemas # Import UserRegister, MessageResponse etc.
+from src.db.database import AsyncSessionLocal # For direct db interaction in fixtures
+# get_db might be needed if we override dependencies in specific tests, but usually AsyncSessionLocal is enough for fixtures
 
+from datetime import datetime, timedelta, timezone # For time manipulation
+import secrets # For unique naming
+from unittest.mock import patch, AsyncMock # For mocking email sending
+
+
+# Fixtures get_test_db, verified_user_data_and_headers, pending_user_and_token,
+# and helpers get_user_by_email_from_db, get_user_by_username_from_db, get_user_by_id_from_db
+# are now expected to be in conftest.py.
+# We still need imports for types and libraries used directly in tests.
+
+# Old helper functions - to be removed or refactored. For now, just commenting them out
+# async def create_test_user_for_auth(
+#     client: AsyncClient, username: str, email: str, password: str = "password123"
+# ) -> dict:
+#     user_data = {"username": username, "email": email, "password": password}
+#     # This endpoint is public for user creation
+#     response = await client.post("/api/v1/users/", json=user_data) # Old endpoint
+#     assert response.status_code == status.HTTP_200_OK, (
+#         f"Failed to create user {username}: {response.text}"
+#     )
+#     return response.json()
+
+# async def get_user_token_headers(
+#     client: AsyncClient, username: str, password: str = "password123"
+# ) -> dict[str, str]:
+#     login_data = {"username": username, "password": password}
+#     res = await client.post("/api/v1/users/token", data=login_data)
+#     assert res.status_code == 200, (
+#         f"Failed to log in {username}. Status: {res.status_code}, Response: {res.text}"
+#     )
+#     token = res.json()["access_token"]
+#     return {"Authorization": f"Bearer {token}"}
+
+
+# --- Test User Registration ---
 
 @pytest.mark.asyncio
-async def test_create_user_success(client: AsyncClient):
+@patch('app.src.core.email.send_verification_email', new_callable=AsyncMock)
+async def test_register_user_success(mock_send_email: AsyncMock, client: AsyncClient, async_db_session: AsyncSession): # Changed get_test_db to async_db_session
+    unique_suffix = secrets.token_hex(4)
     user_data = {
-        "username": "testuser",
-        "email": "testuser@example.com",
+        "username": f"test_reg_{unique_suffix}",
+        "email": f"test_reg_{unique_suffix}@example.com",
+        "password": "ValidPassword123",
+        "full_name": "Test Registree"
+    }
+    response = await client.post("/api/v1/users/register", json=user_data)
+    assert response.status_code == status.HTTP_202_ACCEPTED
+    assert response.json()["message"] == "Registration initiated. Please check your email to verify your account."
+
+    mock_send_email.assert_called_once()
+    sent_to_email = mock_send_email.call_args[0][0]
+    sent_token = mock_send_email.call_args[0][1]
+    assert sent_to_email == user_data["email"]
+    assert len(sent_token) > 10 # Token should be reasonably long
+
+    # Verify user in DB (using helper from conftest)
+    db_user = await get_user_by_email_from_db(async_db_session, user_data["email"]) # Changed get_test_db to async_db_session
+    assert db_user is not None
+    assert db_user.username == user_data["username"]
+    assert db_user.full_name == user_data["full_name"]
+    assert db_user.email_verified is False
+    assert db_user.email_verification_token == sent_token
+    assert db_user.email_verification_token_expires_at is not None
+    assert db_user.email_verification_token_expires_at > datetime.now(timezone.utc)
+
+@pytest.mark.asyncio
+async def test_register_user_email_conflict_verified(client: AsyncClient, verified_user_data_and_headers: Dict[str, Any]): # Fixture from conftest
+    # verified_user_data_and_headers already created a verified user
+    existing_user_email = verified_user_data_and_headers["email"]
+    user_data_conflict = {
+        "username": f"conflict_user_{secrets.token_hex(3)}",
+        "email": existing_user_email, # Same email as verified user
         "password": "password123",
+        "full_name": "Conflict User"
     }
-    response = await client.post("/api/v1/users/", json=user_data)
-    assert response.status_code == status.HTTP_200_OK
-    data = response.json()
-    assert data["email"] == user_data["email"]
-    assert data["username"] == user_data["username"]
-    assert "id" in data
-    assert "hashed_password" not in data  # Ensure password is not returned
-
-    # Login as the created user
-    login_data = {"username": user_data["username"], "password": user_data["password"]}
-    login_response = await client.post("/api/v1/users/token", data=login_data)
-    assert login_response.status_code == status.HTTP_200_OK
-    token = login_response.json()["access_token"]
-    headers = {"Authorization": f"Bearer {token}"}
-
-    # Verify user is in DB by trying to get them
-    user_id = data["id"]
-    response = await client.get(f"/api/v1/users/{user_id}", headers=headers)
-    assert response.status_code == status.HTTP_200_OK
-    assert response.json()["email"] == user_data["email"]
-
-
-@pytest.mark.asyncio
-async def test_create_user_duplicate_email(client: AsyncClient):
-    user_data = {
-        "username": "testuser1",
-        "email": "testuser1@example.com",
-        "password": "password123",
-    }
-    response1 = await client.post("/api/v1/users/", json=user_data)
-    assert response1.status_code == status.HTTP_200_OK
-
-    user_data_duplicate_email = {
-        "username": "testuser2",  # Different username
-        "email": "testuser1@example.com",  # Same email
-        "password": "password456",
-    }
-    response2 = await client.post("/api/v1/users/", json=user_data_duplicate_email)
-    assert response2.status_code == status.HTTP_400_BAD_REQUEST
-    assert (
-        "user with this email already exists" in response2.json()["detail"].lower()
-    )  # Adjusted to match router message
-
-
-@pytest.mark.asyncio
-async def test_create_user_duplicate_username(client: AsyncClient):
-    user_data = {
-        "username": "testuser_unique_username",
-        "email": "unique_email@example.com",
-        "password": "password123",
-    }
-    response1 = await client.post("/api/v1/users/", json=user_data)
-    assert response1.status_code == status.HTTP_200_OK
-
-    user_data_duplicate_username = {
-        "username": "testuser_unique_username",  # Same username
-        "email": "another_unique_email@example.com",  # Different email
-        "password": "password456",
-    }
-    response2 = await client.post("/api/v1/users/", json=user_data_duplicate_username)
-    assert response2.status_code == status.HTTP_400_BAD_REQUEST
-    assert (
-        "user with this username already exists" in response2.json()["detail"].lower()
-    )  # Adjusted
-
-
-@pytest.mark.asyncio
-async def test_read_user_not_found(
-    client: AsyncClient,
-    normal_user_token_headers: dict[str, str],  # Changed
-):
-    response = await client.get(
-        "/api/v1/users/99999",
-        headers=normal_user_token_headers,  # Changed
-    )  # Non-existent user ID
-    assert response.status_code == status.HTTP_404_NOT_FOUND
-
-
-async def create_test_user_for_auth(
-    client: AsyncClient, username: str, email: str, password: str = "password123"
-) -> dict:
-    user_data = {"username": username, "email": email, "password": password}
-    # This endpoint is public for user creation
-    response = await client.post("/api/v1/users/", json=user_data)
-    assert response.status_code == status.HTTP_200_OK, (
-        f"Failed to create user {username}: {response.text}"
-    )
-    return response.json()
-
-
-async def get_user_token_headers(
-    client: AsyncClient, username: str, password: str = "password123"
-) -> dict[str, str]:
-    login_data = {"username": username, "password": password}
-    res = await client.post("/api/v1/users/token", data=login_data)
-    assert res.status_code == 200, (
-        f"Failed to log in {username}. Status: {res.status_code}, Response: {res.text}"
-    )
-    token = res.json()["access_token"]
-    return {"Authorization": f"Bearer {token}"}
-
-
-# User Update Authorization Tests
-@pytest.mark.asyncio
-async def test_update_own_user_details(
-    client: AsyncClient, normal_user_token_headers: dict[str, str], normal_user: User
-):
-    update_data = {"email": "updated_normal_user@example.com"}
-    response = await client.put(
-        f"/api/v1/users/{normal_user.id}",
-        json=update_data,
-        headers=normal_user_token_headers,
-    )
-    assert response.status_code == status.HTTP_200_OK
-    assert response.json()["email"] == update_data["email"]
-
-
-@pytest.mark.asyncio
-async def test_normal_user_cannot_update_other_user(
-    client: AsyncClient, normal_user_token_headers: dict[str, str], normal_user: User
-):
-    # Create 'other_user'
-    other_user_data = await create_test_user_for_auth(
-        client, "otheruser_update_target", "other_update_target@example.com"
-    )
-    other_user_id = other_user_data["id"]
-
-    assert normal_user.id != other_user_id, (
-        "Normal user and other user should have different IDs"
-    )
-
-    update_data = {"email": "other_user_hacked@example.com"}
-    response = await client.put(
-        f"/api/v1/users/{other_user_id}",
-        json=update_data,
-        headers=normal_user_token_headers,
-    )
-    assert response.status_code == status.HTTP_403_FORBIDDEN
-
-
-# User Delete Authorization Tests
-@pytest.mark.asyncio
-async def test_normal_user_can_delete_self(client: AsyncClient):
-    # Create a new user specifically for this test to avoid issues with existing fixtures' tokens
-    user_to_delete_data = await create_test_user_for_auth(
-        client, "user_self_delete", "self_delete@example.com"
-    )
-    user_to_delete_id = user_to_delete_data["id"]
-    user_to_delete_headers = await get_user_token_headers(client, "user_self_delete")
-
-    response = await client.delete(
-        f"/api/v1/users/{user_to_delete_id}", headers=user_to_delete_headers
-    )
-    assert response.status_code == status.HTTP_200_OK
-
-    # Verify deletion
-    get_response = await client.get(
-        f"/api/v1/users/{user_to_delete_id}", headers=user_to_delete_headers
-    )  # Token won't work anymore
-    assert get_response.status_code == status.HTTP_401_UNAUTHORIZED
-
-
-@pytest.mark.asyncio
-async def test_normal_user_cannot_delete_other_user(
-    client: AsyncClient, normal_user_token_headers: dict[str, str], normal_user: User
-):
-    # Create 'other_user' to be the target
-    other_user_data = await create_test_user_for_auth(
-        client, "otheruser_delete_target", "other_delete_target@example.com"
-    )
-    other_user_id = other_user_data["id"]
-
-    assert normal_user.id != other_user_id, (
-        "Normal user and other user should have different IDs"
-    )
-
-    response = await client.delete(
-        f"/api/v1/users/{other_user_id}", headers=normal_user_token_headers
-    )
-    assert response.status_code == status.HTTP_403_FORBIDDEN
-
-
-@pytest.mark.asyncio
-async def test_update_user_success(client: AsyncClient):
-    # Create initial user
-    user_data = {
-        "username": "update_me",
-        "email": "update_me@example.com",
-        "password": "P@ssw0rd",  # Changed to a valid password
-    }
-    create_response = await client.post("/api/v1/users/", json=user_data)
-    assert create_response.status_code == status.HTTP_200_OK
-    user_id = create_response.json()["id"]
-
-    # Get auth token for the created user
-    login_response = await client.post(
-        "/api/v1/users/token",
-        data={"username": user_data["username"], "password": user_data["password"]},
-    )
-    assert login_response.status_code == status.HTTP_200_OK
-    token = login_response.json()["access_token"]
-    headers = {"Authorization": f"Bearer {token}"}
-
-    update_data = {
-        "username": "updated_username",
-        "email": "updated_email@example.com",
-    }
-    update_response = await client.put(
-        f"/api/v1/users/{user_id}", json=update_data, headers=headers
-    )
-    assert update_response.status_code == status.HTTP_200_OK
-    updated_user = update_response.json()
-    assert updated_user["username"] == update_data["username"]
-    assert updated_user["email"] == update_data["email"]
-
-    # Verify by getting the user again, re-login to get a new token with the updated username
-    new_login_data = {
-        "username": update_data["username"],  # Use the new username
-        "password": user_data["password"],  # Original password
-    }
-    new_login_response = await client.post("/api/v1/users/token", data=new_login_data)
-    assert new_login_response.status_code == status.HTTP_200_OK
-    new_token = new_login_response.json()["access_token"]
-    new_headers = {"Authorization": f"Bearer {new_token}"}
-
-    get_response = await client.get(
-        f"/api/v1/users/{user_id}", headers=new_headers
-    )  # Use new headers
-    assert get_response.status_code == status.HTTP_200_OK
-    assert get_response.json()["username"] == update_data["username"]
-
-
-@pytest.mark.asyncio
-async def test_update_user_not_found(
-    client: AsyncClient,
-    normal_user_token_headers: dict[str, str],  # Changed
-):
-    update_data = {"username": "ghost_updater"}
-    response = await client.put(
-        "/api/v1/users/99999",
-        json=update_data,
-        headers=normal_user_token_headers,  # Changed
-    )  # Non-existent user ID
-    assert response.status_code == status.HTTP_404_NOT_FOUND
-
-
-@pytest.mark.asyncio
-async def test_update_user_email_conflict(client: AsyncClient):
-    user1 = {
-        "username": "user1_conflict",
-        "email": "user1_conflict@example.com",
-        "password": "password123",
-    }
-    user2 = {
-        "username": "user2_conflict",
-        "email": "user2_conflict@example.com",
-        "password": "password123",
-    }
-    resp1 = await client.post("/api/v1/users/", json=user1)
-    assert resp1.status_code == status.HTTP_200_OK
-    resp2 = await client.post("/api/v1/users/", json=user2)
-    assert resp2.status_code == status.HTTP_200_OK
-    user2_id = resp2.json()["id"]
-
-    # Get auth token for user2
-    login_response = await client.post(
-        "/api/v1/users/token",
-        data={"username": user2["username"], "password": user2["password"]},
-    )
-    assert login_response.status_code == status.HTTP_200_OK
-    token = login_response.json()["access_token"]
-    headers = {"Authorization": f"Bearer {token}"}
-
-    update_data = {
-        "email": user1["email"]
-    }  # Try to update user2's email to user1's email
-    response = await client.put(
-        f"/api/v1/users/{user2_id}", json=update_data, headers=headers
-    )
+    response = await client.post("/api/v1/users/register", json=user_data_conflict)
     assert response.status_code == status.HTTP_400_BAD_REQUEST
-    assert "email already registered" in response.json()["detail"].lower()
-
+    assert "Email or username already registered and verified" in response.json()["detail"]
 
 @pytest.mark.asyncio
-async def test_delete_user_success(
-    client: AsyncClient,
-    normal_user_token_headers: dict[
-        str, str
-    ],  # Added normal_user_token_headers for verification
-):
-    # Create user to be deleted
-    user_data = {
-        "username": "to_be_deleted",
-        "email": "delete_me@example.com",
+async def test_register_user_username_conflict_verified(client: AsyncClient, verified_user_data_and_headers: Dict[str, Any]): # Fixture from conftest
+    existing_user_username = verified_user_data_and_headers["username"]
+    user_data_conflict = {
+        "username": existing_user_username, # Same username as verified user
+        "email": f"conflict_email_{secrets.token_hex(3)}@example.com",
         "password": "password123",
+        "full_name": "Conflict User"
     }
-    create_response = await client.post("/api/v1/users/", json=user_data)
-    assert create_response.status_code == status.HTTP_200_OK
-    user_id = create_response.json()["id"]
+    response = await client.post("/api/v1/users/register", json=user_data_conflict)
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert "Email or username already registered and verified" in response.json()["detail"]
 
-    # Get auth token for the created user ("to_be_deleted")
-    login_data_tobedeleted = {
-        "username": user_data["username"],
-        "password": user_data["password"],
+@pytest.mark.asyncio
+async def test_register_user_email_pending_valid_token(client: AsyncClient, pending_user_and_token: Dict[str, Any]): # Fixture from conftest
+    # pending_user_and_token fixture creates a user who is pending verification
+    user_data_conflict = {
+        "username": f"new_attempt_{secrets.token_hex(3)}", # Different username
+        "email": pending_user_and_token["email"], # Same email as pending user
+        "password": "newpassword123",
+        "full_name": "New Attempt FullName"
     }
-    login_response_tobedeleted = await client.post(
-        "/api/v1/users/token", data=login_data_tobedeleted
-    )
-    assert login_response_tobedeleted.status_code == status.HTTP_200_OK
-    token_tobedeleted = login_response_tobedeleted.json()["access_token"]
-    headers_tobedeleted = {"Authorization": f"Bearer {token_tobedeleted}"}
+    response = await client.post("/api/v1/users/register", json=user_data_conflict)
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert "Email or username already registered or pending verification with a valid token" in response.json()["detail"]
 
-    # Delete user with their own token
-    delete_response = await client.delete(
-        f"/api/v1/users/{user_id}", headers=headers_tobedeleted
-    )
-    assert delete_response.status_code == status.HTTP_200_OK
+@pytest.mark.asyncio
+@patch('app.src.core.email.send_verification_email', new_callable=AsyncMock)
+async def test_reregister_user_email_pending_expired_token(mock_send_email: AsyncMock, client: AsyncClient, pending_user_and_token: Dict[str, Any], async_db_session: AsyncSession): # Changed get_test_db
+    # Make the token for the pending user expired
+    user_model: User = pending_user_and_token["user_model"]
+    user_model.email_verification_token_expires_at = datetime.now(timezone.utc) - timedelta(hours=1)
+    async_db_session.add(user_model)
+    await async_db_session.commit()
+    await async_db_session.refresh(user_model)
 
-    # Verify user's token is now invalid
-    get_response_after_delete = await client.get(
-        f"/api/v1/users/{user_id}", headers=headers_tobedeleted
-    )
-    assert get_response_after_delete.status_code == status.HTTP_401_UNAUTHORIZED
+    new_password = "new_password_for_reregister123"
+    new_full_name = "Reregistered User Name"
+    reregister_data = {
+        "username": pending_user_and_token["username"], # Can be same or different, email is key here
+        "email": pending_user_and_token["email"],
+        "password": new_password,
+        "full_name": new_full_name
+    }
 
-    # Verify user is actually deleted using another authenticated user's token
-    get_response_with_other_user = await client.get(
-        f"/api/v1/users/{user_id}",
-        headers=normal_user_token_headers,  # normal_user is presumably different
-    )
-    assert get_response_with_other_user.status_code == status.HTTP_404_NOT_FOUND
+    response = await client.post("/api/v1/users/register", json=reregister_data)
+    assert response.status_code == status.HTTP_202_ACCEPTED
+    mock_send_email.assert_called_once()
+
+    # Verify user in DB is updated
+    db_user = await get_user_by_email_from_db(async_db_session, pending_user_and_token["email"]) # Changed get_test_db
+    assert db_user is not None
+    assert db_user.id == pending_user_and_token["id"] # Should be the same user record
+    assert db_user.full_name == new_full_name
+    assert db_user.email_verified is False
+    assert db_user.email_verification_token != pending_user_and_token["token"] # New token
+    assert db_user.email_verification_token_expires_at > datetime.now(timezone.utc)
+    # Check if password was updated (optional: hash and compare, or just trust the logic)
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "payload, error_detail_part",
+    [
+        ({"username": "u", "email": "a@b.com", "password": "ValidPassword123"}, "username"), # Username too short
+        ({"username": "test", "email": "not-an-email", "password": "ValidPassword123"}, "email"), # Invalid email
+        ({"username": "test", "email": "a@b.com", "password": "short"}, "password"), # Password too short
+        ({"username": "test", "email": "a@b.com", "password": "ValidPassword123", "full_name": "a"*101}, "full_name"), # Full name too long
+    ]
+)
+async def test_register_user_invalid_payload(client: AsyncClient, payload: Dict[str, Any], error_detail_part: str):
+    # Fill in missing required fields if not in payload for partial tests
+    if "username" not in payload: payload["username"] = "validuser"
+    if "email" not in payload: payload["email"] = "valid@example.com"
+    if "password" not in payload: payload["password"] = "ValidPassword123"
+
+    response = await client.post("/api/v1/users/register", json=payload)
+    assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+    # Example check, the actual detail might be more specific
+    # assert error_detail_part in str(response.json()["detail"]).lower()
+
+
+# --- End Test User Registration ---
+
+# --- Test Email Verification ---
+
+@pytest.mark.asyncio
+async def test_verify_email_success(client: AsyncClient, pending_user_and_token: Dict[str, Any], async_db_session: AsyncSession): # Changed get_test_db
+    token = pending_user_and_token["token"]
+    response = await client.get(f"/api/v1/users/verify-email?token={token}")
+    assert response.status_code == status.HTTP_200_OK
+    assert response.json()["message"] == "Email verified successfully. You can now log in."
+
+    db_user = await get_user_by_email_from_db(async_db_session, pending_user_and_token["email"]) # Changed get_test_db
+    assert db_user is not None
+    assert db_user.email_verified is True
+    assert db_user.email_verification_token is None
+    assert db_user.email_verification_token_expires_at is None
+
+@pytest.mark.asyncio
+async def test_verify_email_invalid_token(client: AsyncClient):
+    response = await client.get("/api/v1/users/verify-email?token=thisisclearlyaninvalidtoken")
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert "Invalid verification token" in response.json()["detail"]
+
+@pytest.mark.asyncio
+async def test_verify_email_expired_token(client: AsyncClient, pending_user_and_token: Dict[str, Any], async_db_session: AsyncSession): # Changed get_test_db
+    user_model: User = pending_user_and_token["user_model"]
+    user_model.email_verification_token_expires_at = datetime.now(timezone.utc) - timedelta(days=1)
+    async_db_session.add(user_model)
+    await async_db_session.commit()
+
+    token = pending_user_and_token["token"]
+    response = await client.get(f"/api/v1/users/verify-email?token={token}")
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert "Verification token expired" in response.json()["detail"]
+
+    # Check DB user is still unverified
+    db_user = await get_user_by_email_from_db(async_db_session, pending_user_and_token["email"]) # Changed get_test_db
+    assert db_user is not None
+    assert db_user.email_verified is False
+    assert db_user.email_verification_token == token # Token should still be there
+
+@pytest.mark.asyncio
+async def test_verify_email_already_verified(client: AsyncClient, verified_user_data_and_headers: Dict[str, Any]): # Fixture from conftest
+    # Attempt to verify an already verified user (e.g. with a made-up token, or if the old token was somehow known)
+    # The endpoint should ideally not find the user by a token that's already been used and cleared.
+    # If it finds the user but they are verified, it should indicate this.
+    # Current implementation: token is cleared, so a second attempt with same token will be "invalid".
+    # If a NEW token was somehow issued for an already verified user, then it might hit "already verified".
+
+    # This test will use a fake token for simplicity, as the original token is cleared.
+    response = await client.get("/api/v1/users/verify-email?token=fake_token_for_verified_user")
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    # The detail message might be "Invalid verification token." if the token isn't found,
+    # or "Email already verified." if user is found by token but already verified.
+    # Given token is cleared, "Invalid verification token" is expected.
+
+    # To specifically test the "Email already verified" path, one would need to:
+    # 1. Create a pending user.
+    # 2. Get their token.
+    # 3. Manually mark them as verified in DB *without* clearing the token.
+    # 4. Then try to verify with the original token.
+    # This is a bit of an edge case for the current logic.
+
+# --- End Test Email Verification ---
+
+# --- Test Login ---
+
+@pytest.mark.asyncio
+async def test_login_unverified_user(client: AsyncClient, pending_user_and_token: Dict[str, Any]): # Fixture from conftest
+    login_payload = {
+        "username": pending_user_and_token["username"],
+        "password": pending_user_and_token["password"]
+    }
+    response = await client.post("/api/v1/users/token", data=login_payload)
+    assert response.status_code == status.HTTP_401_UNAUTHORIZED
+    assert "Email not verified" in response.json()["detail"]
+
+@pytest.mark.asyncio
+async def test_login_verified_user(client: AsyncClient, verified_user_data_and_headers: Dict[str, Any]): # Fixture from conftest
+    # The fixture already performs login, so this test primarily ensures that process was successful
+    # and a token was obtained. We can re-login here explicitly for clarity if desired.
+    login_payload = {
+        "username": verified_user_data_and_headers["username"],
+        "password": verified_user_data_and_headers["raw_password"]
+    }
+    response = await client.post("/api/v1/users/token", data=login_payload)
+    assert response.status_code == status.HTTP_200_OK
+    token_data = response.json()
+    assert "access_token" in token_data
+    assert token_data["token_type"] == "bearer"
+
+# --- End Test Login ---
+
+# --- Test Resend Verification Email ---
+
+@pytest.mark.asyncio
+@patch('app.src.core.email.send_verification_email', new_callable=AsyncMock)
+async def test_resend_verification_email_success(mock_send_email: AsyncMock, client: AsyncClient, pending_user_and_token: Dict[str, Any], async_db_session: AsyncSession): # Changed get_test_db
+    payload = {"email": pending_user_and_token["email"]}
+    response = await client.post("/api/v1/users/resend-verification-email", json=payload)
+    assert response.status_code == status.HTTP_202_ACCEPTED
+    assert response.json()["message"] == "Verification email resent. Please check your inbox."
+
+    mock_send_email.assert_called_once()
+    sent_to_email = mock_send_email.call_args[0][0]
+    new_token_sent = mock_send_email.call_args[0][1]
+    assert sent_to_email == pending_user_and_token["email"]
+
+    db_user = await get_user_by_email_from_db(async_db_session, pending_user_and_token["email"]) # Changed get_test_db
+    assert db_user is not None
+    assert db_user.email_verification_token == new_token_sent
+    assert db_user.email_verification_token != pending_user_and_token["token"] # Ensure token changed
+    assert db_user.email_verification_token_expires_at > datetime.now(timezone.utc)
+
+@pytest.mark.asyncio
+async def test_resend_verification_email_for_verified_user(client: AsyncClient, verified_user_data_and_headers: Dict[str, Any]): # Fixture from conftest
+    payload = {"email": verified_user_data_and_headers["email"]}
+    response = await client.post("/api/v1/users/resend-verification-email", json=payload)
+    assert response.status_code == status.HTTP_400_BAD_REQUEST # As per current backend logic
+    assert "Email is already verified" in response.json()["detail"]
+
+@pytest.mark.asyncio
+async def test_resend_verification_email_non_existent_user(client: AsyncClient):
+    payload = {"email": "nonexistent@example.com"}
+    response = await client.post("/api/v1/users/resend-verification-email", json=payload)
+    assert response.status_code == status.HTTP_404_NOT_FOUND
+    assert "User with this email not found" in response.json()["detail"]
+
+# --- End Test Resend Verification Email ---
+
+# --- Test Initiate Email Change (PUT /api/v1/users/me/email) ---
+
+@pytest.mark.asyncio
+@patch('app.src.core.email.send_email_change_verification_email', new_callable=AsyncMock)
+async def test_change_email_request_success(mock_send_email_change: AsyncMock, client: AsyncClient, verified_user_data_and_headers: Dict[str, Any], async_db_session: AsyncSession): # Changed get_test_db
+    user_info = verified_user_data_and_headers
+    new_email = f"new_{user_info['username']}@example.com"
+    payload = {
+        "new_email": new_email,
+        "password": user_info["raw_password"]
+    }
+    response = await client.put("/api/v1/users/me/email", json=payload, headers=user_info["headers"])
+    assert response.status_code == status.HTTP_202_ACCEPTED
+    assert response.json()["message"] == "Email change initiated. Please check your new email address to verify."
+
+    mock_send_email_change.assert_called_once()
+    sent_to_email = mock_send_email_change.call_args[0][0]
+    sent_token = mock_send_email_change.call_args[0][1]
+    assert sent_to_email == new_email
+
+    db_user = await get_user_by_username_from_db(async_db_session, user_info["username"]) # Fetch by username or ID, Changed get_test_db
+    assert db_user is not None
+    assert db_user.new_email_pending_verification == new_email
+    assert db_user.email_change_token == sent_token
+    assert db_user.email_change_token_expires_at is not None
+    assert db_user.email_change_token_expires_at > datetime.now(timezone.utc)
+    assert db_user.email == user_info["email"] # Original email should still be active
+
+@pytest.mark.asyncio
+async def test_change_email_request_incorrect_password(client: AsyncClient, verified_user_data_and_headers: Dict[str, Any]): # Fixture from conftest
+    user_info = verified_user_data_and_headers
+    payload = {
+        "new_email": f"new_incorrect_pw_{user_info['username']}@example.com",
+        "password": "wrongpassword"
+    }
+    response = await client.put("/api/v1/users/me/email", json=payload, headers=user_info["headers"])
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert "Incorrect password" in response.json()["detail"]
+
+@pytest.mark.asyncio
+async def test_change_email_request_same_email(client: AsyncClient, verified_user_data_and_headers: Dict[str, Any]): # Fixture from conftest
+    user_info = verified_user_data_and_headers
+    payload = {
+        "new_email": user_info["email"], # Same as current email
+        "password": user_info["raw_password"]
+    }
+    response = await client.put("/api/v1/users/me/email", json=payload, headers=user_info["headers"])
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert "New email cannot be the same as the current email" in response.json()["detail"]
+
+@pytest.mark.asyncio
+@patch('app.src.core.email.send_verification_email', new_callable=AsyncMock) # Mock for user2 creation
+async def test_change_email_request_new_email_taken_by_other_verified(mock_send_reg_email_user2: AsyncMock, client: AsyncClient, async_db_session: AsyncSession, verified_user_data_and_headers: Dict[str, Any]): # Changed get_test_db
+    user1_info = verified_user_data_and_headers # This is our current user trying to change email
+
+    # Create another verified user (user2) explicitly
+    unique_suffix_user2 = secrets.token_hex(4)
+    user2_email_target = f"verified_target_{unique_suffix_user2}@example.com"
+    user2_password = "password_user2"
+    user2_data = {
+        "username": f"verified_target_{unique_suffix_user2}",
+        "email": user2_email_target,
+        "password": user2_password,
+        "full_name": "Verified Target User"
+    }
+    # Register user2
+    reg_resp_user2 = await client.post("/api/v1/users/register", json=user2_data)
+    assert reg_resp_user2.status_code == status.HTTP_202_ACCEPTED
+    mock_send_reg_email_user2.assert_called_once()
+
+    # Verify user2
+    user2_in_db_unverified = await get_user_by_email_from_db(async_db_session, user2_data["email"])
+    assert user2_in_db_unverified is not None
+    verify_token_user2 = user2_in_db_unverified.email_verification_token
+    assert verify_token_user2 is not None
+    verify_resp_user2 = await client.get(f"/api/v1/users/verify-email?token={verify_token_user2}")
+    assert verify_resp_user2.status_code == status.HTTP_200_OK
+    # User2 (user2_email_target) is now verified.
+
+    payload_user1_change = {
+        "new_email": user2_email_target, # User1 tries to change to User2's email
+        "password": user1_info["raw_password"]
+    }
+    response = await client.put("/api/v1/users/me/email", json=payload_user1_change, headers=user1_info["headers"])
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert "This email address is already in use by another verified account" in response.json()["detail"]
+
+# --- End Test Initiate Email Change ---
+
+# --- Test Verify Email Change (GET /api/v1/users/verify-email-change) ---
+
+@pytest.mark.asyncio
+@patch('app.src.core.email.send_email_change_verification_email', new_callable=AsyncMock) # Mock for setup part
+async def test_verify_email_change_success(mock_send_email_change_setup: AsyncMock, client: AsyncClient, verified_user_data_and_headers: Dict[str, Any], async_db_session: AsyncSession): # Changed get_test_db
+    user_info = verified_user_data_and_headers
+    new_email = f"new_verified_{user_info['username']}@example.com"
+
+    # 1. Initiate email change
+    initiate_payload = {"new_email": new_email, "password": user_info["raw_password"]}
+    initiate_response = await client.put("/api/v1/users/me/email", json=initiate_payload, headers=user_info["headers"])
+    assert initiate_response.status_code == status.HTTP_202_ACCEPTED
+    mock_send_email_change_setup.assert_called_once() # Ensure email was "sent"
+
+    # 2. Retrieve the change token from DB
+    db_user_before_verify = await get_user_by_username_from_db(async_db_session, user_info["username"]) # Changed get_test_db
+    assert db_user_before_verify is not None
+    assert db_user_before_verify.new_email_pending_verification == new_email
+    assert db_user_before_verify.email_change_token is not None
+    change_token = db_user_before_verify.email_change_token
+
+    # 3. Verify the email change
+    verify_response = await client.get(f"/api/v1/users/verify-email-change?token={change_token}")
+    assert verify_response.status_code == status.HTTP_200_OK
+    assert verify_response.json()["message"] == "Email address updated successfully."
+
+    # 4. Check DB state
+    db_user_after_verify = await get_user_by_username_from_db(async_db_session, user_info["username"]) # Changed get_test_db
+    assert db_user_after_verify is not None
+    assert db_user_after_verify.email == new_email
+    assert db_user_after_verify.new_email_pending_verification is None
+    assert db_user_after_verify.email_change_token is None
+    assert db_user_after_verify.email_change_token_expires_at is None
+
+@pytest.mark.asyncio
+async def test_verify_email_change_invalid_token(client: AsyncClient):
+    response = await client.get("/api/v1/users/verify-email-change?token=invalidchangetoken")
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert "Invalid or no pending email change for this token" in response.json()["detail"]
+
+@pytest.mark.asyncio
+@patch('app.src.core.email.send_email_change_verification_email', new_callable=AsyncMock) # Mock for setup
+async def test_verify_email_change_expired_token(mock_send_email_change_setup: AsyncMock, client: AsyncClient, verified_user_data_and_headers: Dict[str, Any], async_db_session: AsyncSession): # Changed get_test_db
+    user_info = verified_user_data_and_headers
+    new_email = f"expired_change_{user_info['username']}@example.com"
+
+    initiate_payload = {"new_email": new_email, "password": user_info["raw_password"]}
+    await client.put("/api/v1/users/me/email", json=initiate_payload, headers=user_info["headers"])
+
+    db_user = await get_user_by_username_from_db(async_db_session, user_info["username"]) # Changed get_test_db
+    assert db_user is not None
+    change_token = db_user.email_change_token
+
+    # Manually expire the token
+    db_user.email_change_token_expires_at = datetime.now(timezone.utc) - timedelta(days=1)
+    async_db_session.add(db_user)
+    await async_db_session.commit()
+
+    response = await client.get(f"/api/v1/users/verify-email-change?token={change_token}")
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert "Email change token expired" in response.json()["detail"]
+
+    db_user_after = await get_user_by_username_from_db(async_db_session, user_info["username"]) # Changed get_test_db
+    assert db_user_after is not None
+    assert db_user_after.new_email_pending_verification is None # Should be cleared
+    assert db_user_after.email_change_token is None
+    assert db_user_after.email == user_info["email"] # Original email should remain
+
+@pytest.mark.asyncio
+@patch('app.src.core.email.send_email_change_verification_email', new_callable=AsyncMock) # For User A's setup
+@patch('app.src.core.email.send_verification_email', new_callable=AsyncMock) # For User B's registration
+async def test_verify_email_change_target_email_becomes_verified_by_another(
+    mock_send_reg_email_user_b: AsyncMock, # Renamed for clarity
+    mock_send_email_change_setup_user_a: AsyncMock, # Renamed for clarity
+    client: AsyncClient,
+    async_db_session: AsyncSession,
+    verified_user_data_and_headers: Dict[str, Any] # This will be User A
+):
+    user_a_info = verified_user_data_and_headers
+    target_new_email = f"shared_new_target_{secrets.token_hex(3)}@example.com"
+
+    # 1. User A initiates change to target_new_email
+    initiate_payload_a = {"new_email": target_new_email, "password": user_a_info["raw_password"]}
+    await client.put("/api/v1/users/me/email", json=initiate_payload_a, headers=user_a_info["headers"])
+    mock_send_email_change_setup_user_a.assert_called_once() # Ensure User A's email change email was "sent"
+
+    user_a_db = await get_user_by_username_from_db(async_db_session, user_a_info["username"])
+    assert user_a_db is not None
+    token_a = user_a_db.email_change_token
+    assert token_a is not None
+
+    # 2. User B (another verified user) is created and successfully changes their email to target_new_email
+    user_b_unique_suffix = secrets.token_hex(3)
+    user_b_username = f"userB_{user_b_unique_suffix}"
+    user_b_email_orig = f"userB_orig_{user_b_unique_suffix}@example.com"
+    user_b_password = "passwordB123"
+
+    # Register User B
+    reg_payload_b = {"username": user_b_username, "email": user_b_email_orig, "password": user_b_password, "full_name": "User B"}
+    await client.post("/api/v1/users/register", json=reg_payload_b)
+    mock_send_reg_email_user_b.assert_called_once() # User B registration email
+
+    # Verify User B's initial email
+    user_b_db_unverified = await get_user_by_email_from_db(async_db_session, user_b_email_orig)
+    assert user_b_db_unverified is not None
+    verify_token_b_initial = user_b_db_unverified.email_verification_token
+    await client.get(f"/api/v1/users/verify-email?token={verify_token_b_initial}")
+
+    # Login User B
+    login_payload_b = {"username": user_b_username, "password": user_b_password}
+    login_resp_b = await client.post("/api/v1/users/token", data=login_payload_b)
+    headers_b = {"Authorization": f"Bearer {login_resp_b.json()['access_token']}"}
+
+    # User B initiates and verifies change to target_new_email
+    with patch('app.src.core.email.send_email_change_verification_email', new_callable=AsyncMock) as mock_send_email_change_b:
+        initiate_payload_b = {"new_email": target_new_email, "password": user_b_password}
+        await client.put("/api/v1/users/me/email", json=initiate_payload_b, headers=headers_b)
+        mock_send_email_change_b.assert_called_once()
+
+    user_b_db_pending_change = await get_user_by_username_from_db(async_db_session, user_b_username)
+    assert user_b_db_pending_change is not None
+    token_b_change = user_b_db_pending_change.email_change_token
+    assert token_b_change is not None
+
+    verify_response_b = await client.get(f"/api/v1/users/verify-email-change?token={token_b_change}")
+    assert verify_response_b.status_code == status.HTTP_200_OK # User B successfully changes email
+
+    user_b_db_done = await get_user_by_username_from_db(async_db_session, user_b_username)
+    assert user_b_db_done is not None
+    assert user_b_db_done.email == target_new_email
+
+    # 3. User A then tries to use their original token T_A to verify the same email
+    response_a_verify = await client.get(f"/api/v1/users/verify-email-change?token={token_a}")
+    assert response_a_verify.status_code == status.HTTP_400_BAD_REQUEST
+    assert "This email address has been taken by another user" in response_a_verify.json()["detail"]
+
+    user_a_db_after = await get_user_by_username_from_db(async_db_session, user_a_info["username"])
+    assert user_a_db_after is not None
+    assert user_a_db_after.email == user_a_info["email"] # User A's email should not have changed
+    assert user_a_db_after.new_email_pending_verification is None # Should be cleared
+    assert user_a_db_after.email_change_token is None
+
+# --- End Test Verify Email Change ---
+
+# --- Test Read User ---
+@pytest.mark.asyncio
+async def test_read_user_not_found(client: AsyncClient, verified_user_data_and_headers: Dict[str, Any]): # Fixture from conftest
+    headers = verified_user_data_and_headers["headers"]
+    response = await client.get("/api/v1/users/999999", headers=headers)
+    assert response.status_code == status.HTTP_404_NOT_FOUND
+    assert "User not found or not verified" in response.json()["detail"]
+
+@pytest.mark.asyncio
+async def test_read_unverified_user_as_if_not_found(client: AsyncClient, pending_user_and_token: Dict[str, Any], verified_user_data_and_headers: Dict[str, Any]): # Fixtures from conftest
+    # Use another verified user's token to try to read the pending (unverified) user
+    accessor_headers = verified_user_data_and_headers["headers"]
+    pending_user_id = pending_user_and_token["id"]
+
+    response = await client.get(f"/api/v1/users/{pending_user_id}", headers=accessor_headers)
+    assert response.status_code == status.HTTP_404_NOT_FOUND
+    assert "User not found or not verified" in response.json()["detail"]
+
+# --- End Test Read User ---
+
+# --- Test Update User ---
+@pytest.mark.asyncio
+async def test_update_own_user_details_success(client: AsyncClient, verified_user_data_and_headers: Dict[str, Any], async_db_session: AsyncSession): # Changed get_test_db
+    user_info = verified_user_data_and_headers
+    user_id = user_info["id"]
+
+    update_data = {
+        "username": f"updated_{user_info['username']}",
+        "full_name": f"Updated {user_info['full_name']}",
+        "password": "newValidPassword123"
+    }
+    response = await client.put(f"/api/v1/users/{user_id}", json=update_data, headers=user_info["headers"])
+    assert response.status_code == status.HTTP_200_OK
+
+    updated_data_from_response = response.json()
+    assert updated_data_from_response["username"] == update_data["username"]
+    assert updated_data_from_response["full_name"] == update_data["full_name"]
+    assert updated_data_from_response["email"] == user_info["email"] # Email should not change here
+    assert updated_data_from_response["email_verified"] is True
+
+    # Verify in DB
+    db_user = await get_user_by_id_from_db(async_db_session, user_id) # Changed get_test_db, helper from conftest
+    assert db_user is not None
+    assert db_user.username == update_data["username"]
+    assert db_user.full_name == update_data["full_name"]
+    # To check password, try logging in with new password
+    login_payload = {"username": update_data["username"], "password": update_data["password"]}
+    login_response = await client.post("/api/v1/users/token", data=login_payload)
+    assert login_response.status_code == status.HTTP_200_OK
+
+@pytest.mark.asyncio
+@patch('app.src.core.email.send_verification_email', new_callable=AsyncMock) # For user2 creation
+async def test_update_other_user_forbidden(mock_send_reg_email_user2: AsyncMock, client: AsyncClient, verified_user_data_and_headers: Dict[str, Any], async_db_session: AsyncSession): # Fixture from conftest
+    user1_info = verified_user_data_and_headers
+
+    # Create another user (user2) explicitly
+    unique_suffix_user2 = secrets.token_hex(4)
+    user2_data = {
+        "username": f"other_user_{unique_suffix_user2}",
+        "email": f"other_user_{unique_suffix_user2}@example.com",
+        "password": "password_other",
+        "full_name": "Other User FullName"
+    }
+    reg_resp_user2 = await client.post("/api/v1/users/register", json=user2_data)
+    assert reg_resp_user2.status_code == status.HTTP_202_ACCEPTED
+    mock_send_reg_email_user2.assert_called_once()
+
+    user2_in_db_unverified = await get_user_by_email_from_db(async_db_session, user2_data["email"])
+    assert user2_in_db_unverified is not None
+    verify_token_user2 = user2_in_db_unverified.email_verification_token
+    assert verify_token_user2 is not None
+    verify_resp_user2 = await client.get(f"/api/v1/users/verify-email?token={verify_token_user2}")
+    assert verify_resp_user2.status_code == status.HTTP_200_OK
+    user2_id = user2_in_db_unverified.id
+
+    update_data = {"username": "attempted_update_by_other"}
+    # User1 tries to update User2
+    response = await client.put(f"/api/v1/users/{user2_id}", json=update_data, headers=user1_info["headers"])
+    assert response.status_code == status.HTTP_403_FORBIDDEN
+    assert "Not authorized to update this user account" in response.json()["detail"]
+
+@pytest.mark.asyncio
+async def test_update_unverified_user_forbidden(client: AsyncClient, pending_user_and_token: Dict[str, Any], verified_user_data_and_headers: Dict[str, Any]): # Fixtures from conftest
+    # Even if an admin or someone could try, updating unverified user is forbidden
+    # For this test, we'll use a verified user's headers trying to update a pending user.
+    # This scenario might not be reachable if get_object_or_404 on user_id already filters out unverified.
+    # The route for PUT /{user_id} should first fetch the target_user then check if target_user.email_verified.
+
+    accessor_headers = verified_user_data_and_headers["headers"]
+    pending_user_id = pending_user_and_token["id"]
+
+    update_data = {"full_name": "Trying to update pending"}
+    response = await client.put(f"/api/v1/users/{pending_user_id}", json=update_data, headers=accessor_headers)
+    # Depending on implementation: could be 404 if unverified users are treated as "not found" for modification,
+    # or 403 if found but modification is disallowed. The backend implements 403.
+    assert response.status_code == status.HTTP_403_FORBIDDEN
+    assert "Cannot modify an unverified user account" in response.json()["detail"]
 
 
 @pytest.mark.asyncio
-async def test_delete_user_not_found(
-    client: AsyncClient,
-    normal_user_token_headers: dict[str, str],  # Changed
-):
-    response = await client.delete(
-        "/api/v1/users/99999",
-        headers=normal_user_token_headers,  # Changed
-    )  # Non-existent user ID
+@patch('app.src.core.email.send_verification_email', new_callable=AsyncMock) # For user2 creation
+async def test_update_user_username_conflict(mock_send_reg_email_user2: AsyncMock, client: AsyncClient, verified_user_data_and_headers: Dict[str, Any], async_db_session: AsyncSession): # Fixture from conftest
+    user1_info = verified_user_data_and_headers
+
+    # Create another user (user2) explicitly
+    unique_suffix_user2 = secrets.token_hex(4)
+    user2_username_target = f"conflict_user_{unique_suffix_user2}"
+    user2_data = {
+        "username": user2_username_target,
+        "email": f"conflict_user_{unique_suffix_user2}@example.com",
+        "password": "password_conflict",
+        "full_name": "Conflict User FullName"
+    }
+    reg_resp_user2 = await client.post("/api/v1/users/register", json=user2_data)
+    assert reg_resp_user2.status_code == status.HTTP_202_ACCEPTED
+    mock_send_reg_email_user2.assert_called_once()
+
+    user2_in_db_unverified = await get_user_by_email_from_db(async_db_session, user2_data["email"])
+    assert user2_in_db_unverified is not None
+    verify_token_user2 = user2_in_db_unverified.email_verification_token
+    assert verify_token_user2 is not None
+    verify_resp_user2 = await client.get(f"/api/v1/users/verify-email?token={verify_token_user2}")
+    assert verify_resp_user2.status_code == status.HTTP_200_OK
+    # user2_username_target is now a verified username
+
+    update_data = {"username": user2_username_target} # User1 tries to take User2's username
+    response = await client.put(f"/api/v1/users/{user1_info['id']}", json=update_data, headers=user1_info["headers"])
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert "Username already taken" in response.json()["detail"]
+
+@pytest.mark.asyncio
+async def test_update_user_not_found_for_update(client: AsyncClient, verified_user_data_and_headers: Dict[str, Any]): # Fixture from conftest
+    headers = verified_user_data_and_headers["headers"]
+    update_data = {"username": "ghost_updater"}
+    response = await client.put("/api/v1/users/999999", json=update_data, headers=headers)
     assert response.status_code == status.HTTP_404_NOT_FOUND
+    assert "User not found" in response.json()["detail"] # Assuming get_object_or_404 raises this
+
+# --- End Test Update User ---
+
+# --- Test Delete User ---
+@pytest.mark.asyncio
+@patch('app.src.core.email.send_verification_email', new_callable=AsyncMock)
+async def test_delete_own_user_success(mock_reg_email: AsyncMock, client: AsyncClient, async_db_session: AsyncSession): # Changed get_test_db
+    # Setup: Create a user, verify, login to get their own headers for deletion
+    unique_suffix = f"del_me_{secrets.token_hex(3)}"
+    user_email = f"{unique_suffix}@example.com"
+    user_username = unique_suffix
+    user_password = "passwordToDelete123"
+    user_full_name = "User To Delete"
+
+    reg_payload = {"email": user_email, "username": user_username, "password": user_password, "full_name": user_full_name}
+    await client.post("/api/v1/users/register", json=reg_payload)
+    mock_reg_email.assert_called_once() # Ensure email mock is used correctly
+
+    user_in_db = await get_user_by_email_from_db(async_db_session, user_email) # Changed get_test_db
+    assert user_in_db is not None
+    verify_token = user_in_db.email_verification_token
+    await client.get(f"/api/v1/users/verify-email?token={verify_token}")
+
+    login_resp = await client.post("/api/v1/users/token", data={"username": user_username, "password": user_password})
+    user_id_to_delete = user_in_db.id
+    headers_to_delete = {"Authorization": f"Bearer {login_resp.json()['access_token']}"}
+
+    # Perform delete
+    delete_response = await client.delete(f"/api/v1/users/{user_id_to_delete}", headers=headers_to_delete)
+    assert delete_response.status_code == status.HTTP_200_OK
+    assert f"User {user_id_to_delete} deleted successfully" in delete_response.json()["message"]
+
+    # Verify user is deleted from DB
+    deleted_user_in_db = await get_user_by_id_from_db(async_db_session, user_id_to_delete) # Changed get_test_db, helper from conftest
+    assert deleted_user_in_db is None
+
+    # Verify token is invalid (optional, as user is gone)
+    # get_response_after_delete = await client.get(f"/api/v1/users/{user_id_to_delete}", headers=headers_to_delete)
+    # assert get_response_after_delete.status_code == status.HTTP_401_UNAUTHORIZED
+
+@pytest.mark.asyncio
+@patch('app.src.core.email.send_verification_email', new_callable=AsyncMock) # For user2 creation
+async def test_delete_other_user_forbidden(mock_send_reg_email_user2: AsyncMock, client: AsyncClient, verified_user_data_and_headers: Dict[str, Any], async_db_session: AsyncSession): # Fixture from conftest
+    user1_info = verified_user_data_and_headers # User1 is attacker
+
+    # Create another user (user2) explicitly
+    unique_suffix_user2 = secrets.token_hex(4)
+    user2_data = {
+        "username": f"delete_other_{unique_suffix_user2}",
+        "email": f"delete_other_{unique_suffix_user2}@example.com",
+        "password": "password_delete_other",
+        "full_name": "Delete Other FullName"
+    }
+    reg_resp_user2 = await client.post("/api/v1/users/register", json=user2_data)
+    assert reg_resp_user2.status_code == status.HTTP_202_ACCEPTED
+    mock_send_reg_email_user2.assert_called_once()
+
+    user2_in_db_unverified = await get_user_by_email_from_db(async_db_session, user2_data["email"])
+    assert user2_in_db_unverified is not None
+    verify_token_user2 = user2_in_db_unverified.email_verification_token
+    assert verify_token_user2 is not None
+    verify_resp_user2 = await client.get(f"/api/v1/users/verify-email?token={verify_token_user2}")
+    assert verify_resp_user2.status_code == status.HTTP_200_OK
+    user2_id = user2_in_db_unverified.id
+
+    response = await client.delete(f"/api/v1/users/{user2_id}", headers=user1_info["headers"])
+    assert response.status_code == status.HTTP_403_FORBIDDEN
+    assert "Not authorized to delete this user account" in response.json()["detail"]
+
+@pytest.mark.asyncio
+async def test_delete_user_not_found(client: AsyncClient, verified_user_data_and_headers: Dict[str, Any]): # Fixture from conftest
+    headers = verified_user_data_and_headers["headers"]
+    response = await client.delete("/api/v1/users/9999999", headers=headers)
+    assert response.status_code == status.HTTP_404_NOT_FOUND
+    assert "User not found" in response.json()["detail"]
+
+
+# --- End Test Delete User ---
+
+# Helper function get_user_by_id_from_db is now in conftest.py

--- a/app/tests/test_users_extended.py
+++ b/app/tests/test_users_extended.py
@@ -1,194 +1,215 @@
 import pytest
+import pytest_asyncio
 from httpx import AsyncClient
 from fastapi import status
-from typing import Any
-from src.models.models import User
+from typing import Any, AsyncGenerator, Dict
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy import select
+import secrets
+from datetime import datetime, timedelta, timezone
+from unittest.mock import patch, AsyncMock
 
+
+from src.models.models import User
+from src.db.database import AsyncSessionLocal # Not needed if async_db_session from conftest is used
+# Helper functions and fixtures like get_user_by_email_from_db, get_test_db, verified_user_data_and_headers
+# are now expected to be in conftest.py.
+
+# We still need User model for type hints if not implicitly handled by fixture types.
+# from src.models.models import User # Already imported for global scope if needed by fixtures
+
+# Import helper functions from conftest if they are to be used directly in tests here
+# (though typically tests use fixtures which internally use these helpers)
+# from ..conftest import get_user_by_email_from_db # Example if needed, but usually not.
 
 @pytest.mark.asyncio
 async def test_password_validation(client: AsyncClient):
-    """Test password validation rules"""
+    """Test password validation rules for registration"""
     # Test too short password
     user_data = {
-        "username": "short_pass",
-        "email": "short@example.com",
+        "username": "short_pass_ext",
+        "email": "short_ext@example.com",
         "password": "123",  # Too short
+        "full_name": "Short Pass"
     }
-    response = await client.post("/api/v1/users/", json=user_data)
+    # Use the new /register endpoint
+    response = await client.post("/api/v1/users/register", json=user_data)
     assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
-    assert (
-        "string should have at least 8 characters"
-        in response.json()["detail"][0]["msg"].lower()
-    )
+    # The exact error message structure might vary with Pydantic v2, check one field
+    assert any("string should have at least 8 characters" in err["msg"].lower() for err in response.json()["detail"])
+
 
     # Test password without numbers
     user_data["password"] = "onlyletters"
-    response = await client.post("/api/v1/users/", json=user_data)
+    user_data["username"] = "letters_pass_ext"
+    user_data["email"] = "letters_ext@example.com"
+    response = await client.post("/api/v1/users/register", json=user_data)
     assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
-    assert (
-        "password must contain at least one number"
-        in response.json()["detail"][0]["msg"].lower()
-    )
+    assert any("password must contain at least one number" in err["msg"].lower() for err in response.json()["detail"])
+
 
     # Test password without letters
     user_data["password"] = "12345678"
-    response = await client.post("/api/v1/users/", json=user_data)
+    user_data["username"] = "numbers_pass_ext"
+    user_data["email"] = "numbers_ext@example.com"
+    response = await client.post("/api/v1/users/register", json=user_data)
     assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
-    assert (
-        "password must contain at least one letter"
-        in response.json()["detail"][0]["msg"].lower()
-    )
+    assert any("password must contain at least one letter" in err["msg"].lower() for err in response.json()["detail"])
 
 
 @pytest.mark.asyncio
-async def test_token_expiry(client: AsyncClient):
-    """Test token expiration"""
-    # Create a user
-    user_data = {
-        "username": "token_test",
-        "email": "token@example.com",
-        "password": "testpass123",
+@patch('app.src.core.email.send_verification_email', new_callable=AsyncMock)
+async def test_token_expiry(mock_send_email_te: AsyncMock, client: AsyncClient, async_db_session: AsyncSession): # Changed get_test_db to async_db_session
+    """Test token expiration conceptually (actual time passing is hard)"""
+    # Use the verified_user_data_and_headers logic manually to get headers
+    unique_suffix = secrets.token_hex(4)
+    raw_password = "password123"
+    user_payload = {
+        "username": f"token_expiry_{unique_suffix}",
+        "email": f"token_expiry_{unique_suffix}@example.com",
+        "password": raw_password,
+        "full_name": "Token Expiry Test"
     }
-    create_response = await client.post("/api/v1/users/", json=user_data)
-    assert create_response.status_code == status.HTTP_200_OK
+
+    register_response = await client.post("/api/v1/users/register", json=user_payload)
+    assert register_response.status_code == status.HTTP_202_ACCEPTED
+    mock_send_email_te.assert_called_once()
+
+    # Using get_user_by_email_from_db from conftest.py implicitly via async_db_session
+    user_in_db = await get_user_by_email_from_db(async_db_session, user_payload["email"]) # Changed get_test_db
+    assert user_in_db is not None
+    verification_token = user_in_db.email_verification_token
+    assert verification_token is not None
+
+    verify_response = await client.get(f"/api/v1/users/verify-email?token={verification_token}")
+    assert verify_response.status_code == status.HTTP_200_OK
 
     # Get token
-    login_data = {"username": "token_test", "password": "testpass123"}
+    login_data = {"username": user_payload["username"], "password": raw_password}
     token_response = await client.post("/api/v1/users/token", data=login_data)
     assert token_response.status_code == status.HTTP_200_OK
     token = token_response.json()["access_token"]
     headers = {"Authorization": f"Bearer {token}"}
 
-    # Use token immediately (should work for /me endpoint)
+    # Use token immediately
     response = await client.get("/api/v1/users/me", headers=headers)
     assert response.status_code == status.HTTP_200_OK
-    assert response.json()["username"] == user_data["username"]
+    assert response.json()["username"] == user_payload["username"]
 
-    # Note: In a real test environment, we'd need a way to fast-forward time
-    # or configure shorter token expiry for testing.
-    # This part remains a conceptual placeholder.
-    # Assuming time has passed and token expired:
-    # e.g. time.sleep(ACCESS_TOKEN_EXPIRE_MINUTES * 60 + 1)
-    # response_expired = await client.get("/api/v1/users/me", headers=headers)
-    # assert response_expired.status_code == status.HTTP_401_UNAUTHORIZED
+    # Conceptual part: If token expired, /me would return 401
+    # To test this properly, one might mock `datetime.utcnow()` in the security module
+    # or use a very short token lifetime if configurable.
+    # For now, this test primarily checks token generation and immediate use after full verification.
 
 
 @pytest.mark.asyncio
 async def test_user_email_format_validation(client: AsyncClient):
-    """Test email format validation"""
+    """Test email format validation for registration"""
     invalid_emails = [
-        "",  # Empty
-        "notanemail",  # No @ symbol
-        "@nodomain",  # No local part
-        "no@domain",  # Incomplete domain
-        "spaces in@email.com",  # Spaces in local part
-        "multiple@@at.com",  # Multiple @ symbols
+        "", "notanemail", "@nodomain", "no@domain", "spaces in@email.com", "multiple@@at.com",
     ]
-
+    username_counter = 0
     for email in invalid_emails:
         user_data = {
-            "username": "email_test",
+            "username": f"email_val_ext_{username_counter}",
             "email": email,
             "password": "testpass123",
+            "full_name": "Email Test"
         }
-        response = await client.post("/api/v1/users/", json=user_data)
-        assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY, (
-            f"Email {email} should be invalid"
-        )
-        assert (
-            "value is not a valid email address"
-            in response.json()["detail"][0]["msg"].lower()
-        )
+        username_counter +=1
+        response = await client.post("/api/v1/users/register", json=user_data) # Use new endpoint
+        assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY, f"Email {email} should be invalid"
+        assert any("value is not a valid email address" in err["msg"].lower() for err in response.json()["detail"])
 
 
 @pytest.mark.asyncio
 async def test_username_format_validation(client: AsyncClient):
-    """Test username format validation"""
+    """Test username format validation for registration"""
     test_cases = [
-        ("", "string should have at least 3 characters"),  # Empty
-        ("a", "string should have at least 3 characters"),  # Too short
-        ("a" * 51, "string should have at most 50 characters"),  # Too long
-        ("user@name", "string should match pattern"),  # Special chars
-        ("user name", "string should match pattern"),  # Spaces
+        ("", "string should have at least 3 characters"),
+        ("a", "string should have at least 3 characters"),
+        ("a" * 51, "string should have at most 50 characters"),
+        ("user@name", "string should match pattern"),
+        ("user name", "string should match pattern"),
     ]
-
-    for username, expected_error in test_cases:
+    email_counter = 0
+    for username, expected_error_part in test_cases:
         user_data = {
             "username": username,
-            "email": "test@example.com",
+            "email": f"username_val_ext_{email_counter}@example.com",
             "password": "testpass123",
+            "full_name": "Username Test"
         }
-        response = await client.post("/api/v1/users/", json=user_data)
-        assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY, (
-            f"Username {username} should be invalid"
-        )
-        assert expected_error in response.json()["detail"][0]["msg"].lower()
+        email_counter += 1
+        response = await client.post("/api/v1/users/register", json=user_data) # Use new endpoint
+        assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY, f"Username '{username}' should be invalid"
+
+        # Check if any of the error messages contain the expected error part
+        found_error = False
+        for error_detail in response.json()["detail"]:
+            if expected_error_part.lower() in error_detail["msg"].lower():
+                found_error = True
+                break
+        assert found_error, f"Expected error part '{expected_error_part}' not found in {response.json()['detail']}"
 
 
 @pytest.mark.asyncio
-async def test_password_update_validation(
-    client: AsyncClient, normal_user_token_headers: dict[str, str], normal_user: Any
-):
-    """Test password update validation"""
-    # Try to update with invalid password
-    update_data = {"password": "123"}  # Too short
-    response = await client.put(
-        f"/api/v1/users/{normal_user.id}",
-        json=update_data,
-        headers=normal_user_token_headers,
+async def test_password_update_validation(client: AsyncClient, verified_user_data_and_headers: Dict[str, Any]):
+    """Test password update validation for an existing, verified user"""
+    user_info = verified_user_data_and_headers
+
+    # Try to update with invalid password (too short)
+    update_data_invalid = {"password": "123"}
+    response_invalid = await client.put(
+        f"/api/v1/users/{user_info['id']}", # Use user ID from fixture
+        json=update_data_invalid,
+        headers=user_info["headers"], # Use headers from fixture
     )
-    assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+    assert response_invalid.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+    assert any("string should have at least 8 characters" in err["msg"].lower() for err in response_invalid.json()["detail"])
+
 
     # Update with valid password
-    update_data = {"password": "newvalidpass123"}
-    response = await client.put(
-        f"/api/v1/users/{normal_user.id}",
-        json=update_data,
-        headers=normal_user_token_headers,
+    update_data_valid = {"password": "newValidPass123"}
+    response_valid = await client.put(
+        f"/api/v1/users/{user_info['id']}",
+        json=update_data_valid,
+        headers=user_info["headers"],
     )
-    assert response.status_code == status.HTTP_200_OK
+    assert response_valid.status_code == status.HTTP_200_OK
 
     # Try to login with new password
-    login_data = {"username": normal_user.username, "password": "newvalidpass123"}
-    response = await client.post("/api/v1/users/token", data=login_data)
-    assert response.status_code == status.HTTP_200_OK
+    login_data = {"username": user_info["username"], "password": "newValidPass123"}
+    response_login = await client.post("/api/v1/users/token", data=login_data)
+    assert response_login.status_code == status.HTTP_200_OK
 
+# @pytest.mark.asyncio
+# async def test_concurrent_user_updates(
+#     client: AsyncClient,
+#     verified_user_data_and_headers: Dict[str, Any], # Changed to new fixture
+# ):
+#     """Test handling of concurrent updates to the same user.
+#        This test is less relevant for email now, as email changes go through a different flow.
+#        Could be adapted for other fields like 'full_name' or 'username' if needed.
+#        For now, commenting out as direct email update is not the primary concern here.
+#     """
+#     user_info = verified_user_data_and_headers
+#     user_id = user_info["id"]
+#     headers = user_info["headers"]
 
-@pytest.mark.asyncio
-async def test_concurrent_user_updates(
-    client: AsyncClient,
-    normal_user_token_headers: dict[str, str],
-    normal_user: User,
-):
-    """Test handling of concurrent updates to the same user (email field)"""
-    # Simulate two concurrent updates to email
-    update_data1 = {"email": "new_email1@example.com"}
-    update_data2 = {"email": "new_email2@example.com"}
+#     # Simulate two concurrent updates to full_name
+#     update_data1 = {"full_name": "Concurrent Name One"}
+#     update_data2 = {"full_name": "Concurrent Name Two"}
 
-    # Send updates nearly simultaneously
-    # Note: True concurrency is hard to guarantee in tests like this.
-    # This will mostly test if the endpoint can handle rapid sequential updates.
-    response1 = await client.put(
-        f"/api/v1/users/{normal_user.id}",  # Update by ID
-        json=update_data1,
-        headers=normal_user_token_headers,
-    )
-    response2 = await client.put(
-        f"/api/v1/users/{normal_user.id}",  # Update by ID
-        json=update_data2,
-        headers=normal_user_token_headers,
-    )
+#     response1 = await client.put(f"/api/v1/users/{user_id}", json=update_data1, headers=headers)
+#     response2 = await client.put(f"/api/v1/users/{user_id}", json=update_data2, headers=headers)
 
-    # At least one should succeed (or both, if the last one wins)
-    assert (
-        response1.status_code == status.HTTP_200_OK
-        or response2.status_code == status.HTTP_200_OK
-    )
+#     assert (
+#         response1.status_code == status.HTTP_200_OK
+#         or response2.status_code == status.HTTP_200_OK
+#     )
 
-    # Check final state using the /me endpoint with the original token
-    # This assumes the email update doesn't invalidate the token immediately
-    # and that the user is still logged in with the same session.
-    response = await client.get("/api/v1/users/me", headers=normal_user_token_headers)
-    assert response.status_code == status.HTTP_200_OK
-    final_data = response.json()
-    assert final_data["email"] in [update_data1["email"], update_data2["email"]]
+#     response_me = await client.get("/api/v1/users/me", headers=headers)
+#     assert response_me.status_code == status.HTTP_200_OK
+#     final_data = response_me.json()
+#     assert final_data["full_name"] in [update_data1["full_name"], update_data2["full_name"]]

--- a/openapi.json
+++ b/openapi.json
@@ -2,34 +2,151 @@
   "openapi": "3.1.0",
   "info": {
     "title": "SpendShare API - Development",
-    "description": "API for managing expenses, users, and groups in SpendShare.",
-    "version": "0.1.0"
+    "description": "API for managing expenses, users, and groups in SpendShare. Includes email verification workflow.",
+    "version": "0.1.1"
   },
   "paths": {
-    "/api/v1/users/": {
+    "/api/v1/users/register": {
       "post": {
         "tags": [
           "users"
         ],
-        "summary": "Create User Endpoint",
-        "operationId": "create_user_endpoint_api_v1_users__post",
+        "summary": "Register User",
+        "description": "Initiates user registration. Creates a pending user and sends a verification email. The account is not active until the email is verified.",
+        "operationId": "register_user_api_v1_users_register_post",
         "requestBody": {
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/UserCreate"
+                "$ref": "#/components/schemas/UserRegister"
               }
             }
           },
           "required": true
         },
         "responses": {
-          "200": {
-            "description": "Successful Response",
+          "202": {
+            "description": "Registration initiated, verification pending.",
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/UserRead"
+                  "$ref": "#/components/schemas/MessageResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request (e.g., email already exists and is verified, or pending and token still valid, or username taken)",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MessageResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/users/verify-email": {
+      "get": {
+        "tags": [
+          "users"
+        ],
+        "summary": "Verify Email Address",
+        "description": "Verifies a user's email address using a token sent during registration. This is a public endpoint accessed via a link.",
+        "operationId": "verify_email_api_v1_users_verify_email_get",
+        "parameters": [
+          {
+            "name": "token",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Token"
+            },
+            "description": "The email verification token."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Email verified successfully.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MessageResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid, expired, or already used token.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MessageResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error (e.g., token format incorrect)",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/users/resend-verification-email": {
+      "post": {
+        "tags": [
+          "users"
+        ],
+        "summary": "Resend Verification Email",
+        "description": "Resends the email verification link if the previous one expired or was not received. Applies to users in a pending verification state.",
+        "operationId": "resend_verification_email_api_v1_users_resend_verification_email_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ResendVerificationEmailRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "202": {
+            "description": "Verification email has been resent.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MessageResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Email not found in a state eligible for resending verification (e.g., already verified or never registered).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MessageResponse"
                 }
               }
             }
@@ -53,7 +170,7 @@
           "users"
         ],
         "summary": "Search Users Endpoint",
-        "description": "Search for users by username or email.\nReturns a list of users matching the query.\nAccessible to any authenticated user.",
+        "description": "Search for users by username or email. Returns a list of users matching the query. Accessible to any authenticated user. Only returns verified users.",
         "operationId": "search_users_endpoint_api_v1_users_search_get",
         "security": [
           {
@@ -105,7 +222,7 @@
           "users"
         ],
         "summary": "Read Current User Me Endpoint",
-        "description": "Get current logged-in user.",
+        "description": "Get current logged-in and verified user.",
         "operationId": "read_current_user_me_endpoint_api_v1_users_me_get",
         "responses": {
           "200": {
@@ -126,12 +243,124 @@
         ]
       }
     },
+    "/api/v1/users/me/email": {
+      "put": {
+        "tags": [
+          "users"
+        ],
+        "summary": "Change User Email",
+        "description": "Initiates the process for a logged-in user to change their email address. A verification email will be sent to the new address. The email is not updated until verified.",
+        "operationId": "change_user_email_api_v1_users_me_email_put",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UserEmailChangeRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "202": {
+            "description": "Email change initiated. Check new email for verification.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MessageResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request (e.g., new email same as old, new email already in use by another user, password incorrect)",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MessageResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/users/verify-email-change": {
+      "get": {
+        "tags": [
+          "users"
+        ],
+        "summary": "Verify Email Change",
+        "description": "Verifies a new email address for a user after they initiated an email change request. This is a public endpoint accessed via a link containing a token.",
+        "operationId": "verify_email_change_api_v1_users_verify_email_change_get",
+        "parameters": [
+          {
+            "name": "token",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Token"
+            },
+            "description": "The email change verification token."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Email change verified and updated successfully.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MessageResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid, expired, or already used token for email change.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MessageResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/v1/users/{user_id}": {
       "get": {
         "tags": [
           "users"
         ],
         "summary": "Read User Endpoint",
+        "description": "Gets a specific user by ID. Only returns verified users.",
         "operationId": "read_user_endpoint_api_v1_users__user_id__get",
         "security": [
           {
@@ -160,6 +389,16 @@
               }
             }
           },
+          "404": {
+            "description": "User not found or not verified.",
+             "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MessageResponse"
+                }
+              }
+            }
+          },
           "422": {
             "description": "Validation Error",
             "content": {
@@ -177,6 +416,7 @@
           "users"
         ],
         "summary": "Update User Endpoint",
+        "description": "Updates a user's details (username, password, full_name). Email changes must go through the separate email change verification flow. Only affects verified users. User can only update their own details unless they are an admin.",
         "operationId": "update_user_endpoint_api_v1_users__user_id__put",
         "security": [
           {
@@ -215,6 +455,26 @@
               }
             }
           },
+          "403": {
+            "description": "Forbidden (user trying to update another user's details without admin rights)",
+             "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MessageResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "User not found or not verified.",
+             "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MessageResponse"
+                }
+              }
+            }
+          },
           "422": {
             "description": "Validation Error",
             "content": {
@@ -232,6 +492,7 @@
           "users"
         ],
         "summary": "Delete User Endpoint",
+        "description": "Deletes a user. Only affects verified users. User can only delete their own account unless they are an admin.",
         "operationId": "delete_user_endpoint_api_v1_users__user_id__delete",
         "security": [
           {
@@ -251,12 +512,31 @@
         ],
         "responses": {
           "200": {
-            "description": "Successful Response",
+            "description": "Successful Response: User deleted (or marked as deleted)",
             "content": {
               "application/json": {
+                 "schema": {
+                  "$ref": "#/components/schemas/MessageResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden (user trying to delete another user's account without admin rights)",
+             "content": {
+              "application/json": {
                 "schema": {
-                  "type": "integer",
-                  "title": "Response Delete User Endpoint Api V1 Users  User Id  Delete"
+                  "$ref": "#/components/schemas/MessageResponse"
+                }
+              }
+            }
+          },
+           "404": {
+            "description": "User not found or not verified.",
+             "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MessageResponse"
                 }
               }
             }
@@ -280,6 +560,7 @@
           "users"
         ],
         "summary": "Login For Access Token",
+        "description": "Provides an access token for successfully authenticated and verified users.",
         "operationId": "login_for_access_token_api_v1_users_token_post",
         "requestBody": {
           "content": {
@@ -298,6 +579,16 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/Token"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized (e.g., incorrect username/password, or email not verified)",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MessageResponse"
                 }
               }
             }
@@ -1605,6 +1896,92 @@
   },
   "components": {
     "schemas": {
+      "MessageResponse": {
+        "title": "MessageResponse",
+        "type": "object",
+        "properties": {
+          "message": {
+            "type": "string",
+            "title": "Message"
+          }
+        },
+        "required": [
+          "message"
+        ]
+      },
+      "UserRegister": {
+        "title": "UserRegister",
+        "type": "object",
+        "properties": {
+          "email": {
+            "type": "string",
+            "format": "email",
+            "title": "Email"
+          },
+          "password": {
+            "type": "string",
+            "minLength": 8,
+            "title": "Password"
+          },
+          "full_name": {
+            "anyOf": [
+              {
+                "type": "string",
+                "maxLength": 100
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Full Name"
+          },
+          "username": {
+             "type": "string",
+             "maxLength": 50,
+             "minLength": 3,
+             "pattern": "^[a-zA-Z0-9_-]+$",
+             "title": "Username"
+          }
+        },
+        "required": [
+          "email",
+          "password",
+          "username"
+        ]
+      },
+      "ResendVerificationEmailRequest": {
+        "title": "ResendVerificationEmailRequest",
+        "type": "object",
+        "properties": {
+          "email": {
+            "type": "string",
+            "format": "email",
+            "title": "Email"
+          }
+        },
+        "required": [
+          "email"
+        ]
+      },
+      "UserEmailChangeRequest": {
+        "title": "UserEmailChangeRequest",
+        "type": "object",
+        "properties": {
+          "new_email": {
+            "type": "string",
+            "format": "email",
+            "title": "New Email"
+          },
+          "password": {
+            "type": "string",
+            "title": "Current Password (for verification)"
+          }
+        },
+        "required": [
+          "new_email",
+          "password"
+        ]
+      },
       "Body_create_expense_with_participants_endpoint_api_v1_expenses_service__post": {
         "properties": {
           "expense_in": {
@@ -2554,7 +2931,8 @@
           "email",
           "password"
         ],
-        "title": "UserCreate"
+        "title": "UserCreate",
+        "description": "Schema for creating a user directly (e.g. by an admin). For public registration, use UserRegister. Assumes email is pre-verified or verification is handled externally."
       },
       "UserRead": {
         "properties": {
@@ -2573,13 +2951,31 @@
           "id": {
             "type": "integer",
             "title": "Id"
+          },
+          "email_verified": {
+            "type": "boolean",
+            "title": "Email Verified",
+            "description": "Indicates if the user has verified their email address."
+          },
+          "full_name": {
+            "anyOf": [
+              {
+                "type": "string",
+                "maxLength": 100
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Full Name"
           }
         },
         "type": "object",
         "required": [
           "username",
           "email",
-          "id"
+          "id",
+          "email_verified"
         ],
         "title": "UserRead"
       },
@@ -2588,25 +2984,16 @@
           "username": {
             "anyOf": [
               {
-                "type": "string"
+                "type": "string",
+                "maxLength": 50,
+                "minLength": 3,
+                "pattern": "^[a-zA-Z0-9_-]+$"
               },
               {
                 "type": "null"
               }
             ],
             "title": "Username"
-          },
-          "email": {
-            "anyOf": [
-              {
-                "type": "string",
-                "format": "email"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Email"
           },
           "password": {
             "anyOf": [
@@ -2618,11 +3005,24 @@
                 "type": "null"
               }
             ],
-            "title": "Password"
+            "title": "Password (new password)"
+          },
+           "full_name": {
+            "anyOf": [
+              {
+                "type": "string",
+                "maxLength": 100
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Full Name"
           }
         },
         "type": "object",
-        "title": "UserUpdate"
+        "title": "UserUpdate",
+        "description": "Schema for updating user details (username, password, full_name). Email must be updated via the /users/me/email endpoint and subsequent verification."
       },
       "ValidationError": {
         "properties": {

--- a/wiki/feature/user_email_verification.md
+++ b/wiki/feature/user_email_verification.md
@@ -1,0 +1,171 @@
+# User Email Verification Workflow
+
+This document outlines the workflow for user email verification to ensure that users have a valid email address before their account is fully activated.
+
+## 1. Overview
+
+The primary goal of this feature is to enhance account security and data integrity by requiring users to verify their email address upon registration and when changing their email address. Accounts will not be fully created or activated until the provided email address is confirmed. This helps prevent the creation of accounts with fake or mistyped email addresses.
+
+## 2. Key Concepts
+
+*   **Pending User:** A user who has initiated the registration process but has not yet verified their email address.
+    *   Their details (e.g., email, hashed password if provided, verification token) are stored temporarily.
+    *   They cannot log in or access most application features.
+    *   They might have limited access to resend verification email or cancel registration.
+*   **Valid User (Active User):** A user who has successfully verified their email address.
+    *   Their account is fully active in the main user database.
+    *   They have access to all features appropriate to their roles and permissions.
+*   **Verification Token:** A unique, secure, time-sensitive token generated and sent to the user's email address to confirm ownership.
+*   **Email Change Verification:** When a valid user wishes to change their email address, the new email address must also undergo a similar verification process before it becomes the primary email for the account.
+
+## 3. Workflow Steps
+
+### 3.1. New User Registration & Email Verification
+
+1.  **Initiate Registration:**
+    *   User provides necessary registration details (e.g., email, password, name).
+    *   The system checks if the email is already in use (either as a valid user or a pending user).
+        *   If email is in use by a valid user, registration fails with an appropriate error.
+        *   If email is in use by a pending user (and token is still valid), inform the user to check their email or offer to resend verification. If token is expired, allow re-registration.
+2.  **Store Pending User & Generate Token:**
+    *   If the email is available, the system stores the user's registration information in a 'pending' state (e.g., in a separate `pending_users` table or by marking a user record in the main `users` table with a status like `pending_verification`).
+    *   A cryptographically secure, unique verification token with an expiration time (e.g., 24 hours) is generated.
+    *   The token and its expiry are stored with the pending user data.
+3.  **Send Verification Email:**
+    *   An email is sent to the user's provided email address. This email contains a unique link with the verification token (e.g., `https://yourdomain.com/api/v1/users/verify-email?token=THE_TOKEN`).
+4.  **User Clicks Verification Link:**
+    *   The user opens their email and clicks the verification link.
+5.  **System Verifies Token:**
+    *   The backend receives the request from the verification link.
+    *   It extracts the token and looks up the corresponding pending user.
+    *   It checks if the token exists, is not expired, and has not been used before.
+6.  **Activate Account or Handle Error:**
+    *   **If token is valid:**
+        *   The user's account is activated:
+            *   If using a separate `pending_users` table, the data is moved to the main `users` table.
+            *   If using a status field, the user's status is updated to `active` (or `valid`).
+        *   The verification token is marked as used or deleted.
+        *   The user is informed of successful verification (e.g., redirected to a success page or login page).
+    *   **If token is invalid (not found, expired, already used):**
+        *   An appropriate error message is displayed to the user (e.g., "Invalid or expired verification link. Please try registering again or request a new verification email.").
+
+### 3.2. Existing User Email Change & Verification
+
+1.  **Initiate Email Change:**
+    *   A logged-in, valid user requests to change their email address via their profile settings.
+    *   User provides the new email address.
+2.  **Validate New Email & Generate Token:**
+    *   The system checks if the new email address is already in use by another valid user. If so, the change is rejected.
+    *   A new, unique verification token is generated for the *new* email address.
+    *   The new email address, token, and token expiry are temporarily stored, associated with the user's account (e.g., fields like `new_email_pending_verification`, `email_change_token`, `email_change_token_expires_at` on the user's record). The user's current email remains active.
+3.  **Send Verification Email to New Address:**
+    *   An email is sent to the *new* email address with a verification link for the change.
+4.  **User Clicks Verification Link:**
+    *   The user opens their email (the new one) and clicks the verification link.
+5.  **System Verifies Token for Email Change:**
+    *   The backend receives the request.
+    *   It validates the token (exists, not expired, matches the user).
+6.  **Update Email or Handle Error:**
+    *   **If token is valid:**
+        *   The user's primary email address is updated to the new, verified email.
+        *   The temporary email change token and associated data are cleared.
+        *   The user is informed of the successful email change.
+    *   **If token is invalid:**
+        *   An appropriate error message is displayed. The old email remains the primary email.
+
+### 3.3. Handling Unverified Users / Pending State
+
+*   **Login:** Users in a 'pending_verification' state cannot log in or obtain authentication tokens.
+*   **Access Restrictions:** Pending users have no access to API endpoints that require authentication.
+*   **Resend Verification Email:** Provide an option for users to request a new verification email if the original one expired or was not received. This would generate a new token and send a new email.
+*   **Expiration of Pending Accounts:** Pending user records or tokens that have expired and have not been acted upon for a significant period (e.g., 7 days) might be periodically cleaned up by a background job.
+
+## 4. API Impact (Preliminary)
+
+This section outlines expected changes to the `openapi.json` specification.
+
+### 4.1. New/Modified Endpoints
+
+*   **`POST /api/v1/users/register`** (New or Modified `POST /api/v1/users/`)
+    *   **Request:** User registration details (name, email, password).
+    *   **Action:** Creates a pending user, generates a token, sends a verification email.
+    *   **Response:** `202 Accepted` (or similar) indicating that verification is pending. No user data or token returned directly.
+        ```json
+        // Example Response Body (202 Accepted)
+        {
+          "message": "Registration initiated. Please check your email to verify your account."
+        }
+        ```
+
+*   **`GET /api/v1/users/verify-email`**
+    *   **Request:** Query parameter `token` (e.g., `/api/v1/users/verify-email?token=abcdef123456`).
+    *   **Action:** Validates the email verification token. If valid, activates the user account.
+    *   **Response:**
+        *   `200 OK` on successful verification.
+            ```json
+            // Example Response Body (200 OK)
+            {
+              "message": "Email verified successfully. You can now log in."
+            }
+            ```
+        *   `400 Bad Request` for invalid, expired, or already used token.
+            ```json
+            // Example Response Body (400 Bad Request)
+            {
+              "detail": "Invalid or expired verification token."
+            }
+            ```
+
+*   **`POST /api/v1/users/resend-verification-email`** (New)
+    *   **Request:**
+        ```json
+        {
+          "email": "user@example.com"
+        }
+        ```
+    *   **Action:** If the email corresponds to a pending user whose token may have expired, generate a new token and resend the verification email.
+    *   **Response:** `202 Accepted` or `404 Not Found` if email isn't in a pending state.
+
+*   **`PUT /api/v1/users/me/email`** (New or modification to `PUT /api/v1/users/me`)
+    *   **Request (Authenticated):**
+        ```json
+        {
+          "new_email": "new.email@example.com",
+          "password": "current_user_password" // For security, confirm identity
+        }
+        ```
+    *   **Action:** Initiates the email change process for the authenticated user. Sends verification to the new email.
+    *   **Response:** `202 Accepted`.
+        ```json
+        // Example Response Body (202 Accepted)
+        {
+          "message": "Email change initiated. Please check your new email address to verify the change."
+        }
+        ```
+
+*   **`GET /api/v1/users/verify-email-change`** (New)
+    *   **Request:** Query parameter `token` (e.g., `/api/v1/users/verify-email-change?token=uvwxyz789012`).
+    *   **Action:** Validates the token for an email change request. If valid, updates the user's email.
+    *   **Response:**
+        *   `200 OK` on successful verification and change.
+        *   `400 Bad Request` for invalid/expired token.
+
+### 4.2. Schema Updates (Conceptual)
+
+*   **`UserRead` Schema:**
+    *   May need an `email_verified: bool` field or a `status: str` (e.g., "active", "pending_verification"). (Initially, `email_verified: bool` might be simpler if we go with a single user table approach).
+*   **`UserCreate` Schema (for `/users/register`):**
+    *   Standard fields: `email: EmailStr`, `password: str`, `full_name: Optional[str]`.
+*   **New Schemas:**
+    *   `PendingUserCreate` (if using a separate table, internal).
+    *   `TokenData` (for verification token details, internal).
+    *   `ResendVerificationEmailRequest`.
+    *   `UserEmailChangeRequest`.
+
+### 4.3. Modified Existing Endpoints
+
+*   **`POST /api/v1/token` (Login):**
+    *   Must check if the user's email is verified (user is 'active') before issuing an access token. If not verified, return `401 Unauthorized` or `403 Forbidden` with a message like "Email not verified."
+
+This feature request provides a comprehensive guide for implementing the email verification workflow. It will be updated as needed during development.
+```


### PR DESCRIPTION
This commit introduces a comprehensive email verification process for new user registrations and for changes to existing users' email addresses.

Key changes include:

1.  **New User Registration:**
    *   Users registering via `POST /api/v1/users/register` are now created in a pending state.
    *   A unique verification token is generated and sent to their email address (currently mocked via logging).
    *   The account is not active (`email_verified=False`) until the token is used.

2.  **Email Verification:**
    *   A new public endpoint `GET /api/v1/users/verify-email` allows users to verify their email using the token from the verification link.
    *   Upon successful verification, the user's `email_verified` status is set to `True`, and the token is cleared.

3.  **Login Restriction:**
    *   The `POST /api/v1/users/token` (login) endpoint now only grants access tokens to users whose `email_verified` status is `True`.

4.  **Resend Verification:**
    *   `POST /api/v1/users/resend-verification-email` allows pending users to request a new verification email.

5.  **Email Change Workflow:**
    *   Authenticated users can request an email change via `PUT /api/v1/users/me/email`, which requires current password confirmation.
    *   A verification email is sent to the *new* email address.
    *   The email change is finalized via `GET /api/v1/users/verify-email-change` using the token sent to the new address.

6.  **API and Schema Updates:**
    *   `openapi.json` has been updated with all new endpoints and relevant request/response schemas (`UserRegister`, `MessageResponse`, `UserEmailChangeRequest`, etc.).
    *   The `User` SQLAlchemy model and Pydantic `UserRead`/`UserUpdate` schemas were updated to include `email_verified`, `full_name`, and fields for managing verification/change tokens.
    *   The old `POST /api/v1/users/` endpoint for direct user creation has been removed in favor of the new registration flow.

7.  **Testing:**
    *   Comprehensive unit and integration tests have been added for the entire verification workflow, covering various scenarios including token validation, expiry, and conflicts.
    *   Existing user tests were refactored to use new fixtures that create verified users.
    *   Common test fixtures were consolidated into `conftest.py`.

**Important Notes:**

*   **Test Execution:** Due to some limitations during this session, I couldn't get live `pytest` execution results. You should run the implemented tests to confirm the correctness of the changes.
*   **Database Migrations:** This commit includes changes to the `User` database model (new columns). If you're using a migration tool like Alembic, a new migration script needs to be generated and applied. If not, schema changes must be applied manually to the database.
*   **Email Sending:** The email sending functionality is currently mocked (logs to console). A proper email sending service integration is required for actual email delivery.