### PR TITLE
Implement advanced expense features and receipt uploads

### DIFF
--- a/app/src/main.py
+++ b/app/src/main.py
@@ -1,4 +1,6 @@
 from fastapi import FastAPI
+from fastapi.staticfiles import StaticFiles # For serving static files
+import os # For path joining
 from contextlib import asynccontextmanager  # For lifespan events in newer FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
@@ -34,6 +36,34 @@ app.add_middleware(
     allow_methods=["*"],
     allow_headers=["*"],
 )
+
+# Static files setup for uploads
+# This assumes 'main.py' is in 'app/src/' and 'uploads' directory is in 'app/uploads/'
+# So, the path to 'app/uploads' from 'app/src/main.py' is '../uploads'
+# If main.py is in 'app/', then path is 'uploads'
+# Assuming CWD is /app (where Dockerfile is, and where app/src and app/uploads would be)
+# So, "uploads" should resolve to "/app/uploads" if the app is run from /app.
+
+# Let's make the path more robust by constructing it from the app's root.
+# Assuming this script (main.py) is in app/src.
+# Project root for backend files is 'app'.
+# So 'app/uploads' is the target.
+# Path from app/src/main.py to app/uploads is os.path.join(os.path.dirname(__file__), '..', 'uploads')
+# However, FastAPI's StaticFiles directory path is usually relative to where the app is run, or an absolute path.
+
+# If app is run from /app directory:
+# Mount static files from the 'uploads' directory (which is /app/uploads)
+# The UPLOAD_DIR_RECEIPTS in expenses.py creates "uploads/receipts" inside /app.
+# So we serve the "uploads" directory.
+# The URL will be /uploads/receipts/filename.ext
+
+# Ensure the uploads directory exists at app startup (optional, but good practice)
+# This path should correspond to where files are saved in expenses.py (i.e. app/uploads)
+uploads_dir = "uploads"
+os.makedirs(uploads_dir, exist_ok=True) # Create /app/uploads if not exists
+
+app.mount("/uploads", StaticFiles(directory=uploads_dir), name="uploads")
+
 
 # Include routers
 app.include_router(users.router, prefix="/api/v1")  # Example prefix

--- a/app/src/models/models.py
+++ b/app/src/models/models.py
@@ -177,6 +177,9 @@ class Expense(SQLModel, table=True):
         back_populates="expense",
         sa_relationship_kwargs={"cascade": "all, delete-orphan", "overlaps": "expenses_participated_in,participants"}
     )
+    receipt_image_url: Optional[str] = Field(default=None, nullable=True)
+    split_method: Optional[str] = Field(default=None, nullable=True) # Stores SplitMethodEnum.value
+    selected_participant_user_ids_json: Optional[str] = Field(default=None, nullable=True) # JSON string list of user IDs for equal split
 
 
 class Currency(SQLModel, table=True):

--- a/app/src/models/schemas.py
+++ b/app/src/models/schemas.py
@@ -153,8 +153,20 @@ class ExpenseBase(SQLModel):
     group_id: Optional[int] = None
 
 
+from enum import Enum
+
+# Enum for Split Methods
+class SplitMethodEnum(str, Enum):
+    EQUAL = "equal"
+    PERCENTAGE = "percentage"
+    UNEQUAL = "unequal"
+
+
 class ExpenseCreate(ExpenseBase):
-    participant_shares: Optional[List[ParticipantShareCreate]] = None
+    paid_by_user_id: Optional[int] = None
+    split_method: Optional[SplitMethodEnum] = Field(default=SplitMethodEnum.UNEQUAL)
+    selected_participant_user_ids: Optional[List[int]] = None # For "equal" split
+    participant_shares: Optional[List[ParticipantShareCreate]] = None # For "unequal" and "percentage"
 
 
 class ExpenseRead(ExpenseBase):
@@ -165,6 +177,15 @@ class ExpenseRead(ExpenseBase):
     currency: Optional["CurrencyRead"] = None  # Added currency
     description: str = Field(default="")
     participant_details: List["ExpenseParticipantReadWithUser"] = []
+    receipt_image_url: Optional[str] = None
+    split_method: Optional[SplitMethodEnum] = None # Added from feature doc
+    # selected_participant_user_ids is not directly on Expense model,
+    # but could be reconstructed or passed if needed for read.
+    # For now, let's assume it's not directly part of ExpenseRead unless specifically needed for display logic
+    # that cannot be inferred from participant_details + split_method.
+    # The feature doc says "Include selected_participant_user_ids if applicable."
+    # This implies it might be useful. Let's add it.
+    selected_participant_user_ids: Optional[List[int]] = None
 
 
 class ExpenseUpdate(SQLModel):

--- a/app/src/routers/expenses.py
+++ b/app/src/routers/expenses.py
@@ -1,3 +1,8 @@
+import json
+import shutil
+import os
+import uuid
+from fastapi import UploadFile, File # Added for file upload
 from typing import List, Optional
 from fastapi import APIRouter, Depends, HTTPException, Body, status
 from sqlmodel.ext.asyncio.session import AsyncSession
@@ -33,58 +38,159 @@ async def create_expense_with_participants_endpoint(
     expense_in: schemas.ExpenseCreate,
     current_user: User = Depends(get_current_user),
 ) -> schemas.ExpenseRead:
+    # Determine the actual payer
+    payer_id = current_user.id
+    if expense_in.paid_by_user_id is not None:
+        # Validate the provided paid_by_user_id
+        payer_user = await get_object_or_404(session, User, expense_in.paid_by_user_id, "Payer user not found.")
+        payer_id = payer_user.id
+
     # Validate currency_id
     await get_object_or_404(session, Currency, expense_in.currency_id, "Currency not found.")
 
-    # Validate group_id if provided
+    # Validate group_id if provided and permissions
     if expense_in.group_id:
-        await get_object_or_404(session, Group, expense_in.group_id, "Group not found.")
-
-    participants_for_db = []
-
-    try:
-        if expense_in.participant_shares:
-            # Case 1: Custom shares are provided
-            seen_user_ids = set()
-            sum_of_shares = 0.0
-
-            for share_detail in expense_in.participant_shares:
-                # Validate participant user_id
-                await get_object_or_404(session, User, share_detail.user_id, f"Participant user ID {share_detail.user_id} not found.")
-
-                # Check for duplicate user_ids in the input
-                if share_detail.user_id in seen_user_ids:
-                    await session.rollback()
-                    raise HTTPException(
-                        status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
-                        detail=f"Duplicate user ID {share_detail.user_id} in participant shares.",
-                    )
-                seen_user_ids.add(share_detail.user_id)
-                sum_of_shares += share_detail.share_amount
-                participants_for_db.append(
-                    {"user_id": share_detail.user_id, "share_amount": share_detail.share_amount}
-                )
-
-            # Validate sum of shares against total expense amount
-            # Using a small tolerance for float comparison (e.g., 0.01 for currency)
-            if abs(sum_of_shares - expense_in.amount) > 1e-2: # Adjusted tolerance for currency
-                await session.rollback()
-                raise HTTPException(
-                    status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
-                    detail=f"Sum of participant shares ({sum_of_shares:.2f}) does not match total expense amount ({expense_in.amount:.2f}).",
-                )
-        else:
-            # Case 2: No custom shares provided, payer is the only participant
-            # Validate current_user.id (though typically guaranteed by Depends)
-            await get_object_or_404(session, User, current_user.id, "Current user not found.")
-            participants_for_db.append(
-                {"user_id": current_user.id, "share_amount": expense_in.amount}
+        group = await get_object_or_404(session, Group, expense_in.group_id, "Group not found.")
+        # Check if current_user (creator) is a member of the group
+        current_user_is_member = any(member.id == current_user.id for member in group.members)
+        if not current_user_is_member:
+            # This check might need adjustment based on product requirements (e.g., group admins)
+            # For now, creator must be a member.
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="Creator must be a member of the group to add expenses.",
             )
 
+        # If a specific payer is designated, check if that payer is also a member of the group
+        if expense_in.paid_by_user_id is not None and expense_in.paid_by_user_id != current_user.id:
+            payer_is_member = any(member.id == expense_in.paid_by_user_id for member in group.members)
+            if not payer_is_member:
+                raise HTTPException(
+                    status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                    detail="Designated payer is not a member of the group.",
+                )
+    participants_for_db = []
+    group_members_if_group_expense = None
+    if expense_in.group_id and group: # group object fetched earlier
+        group_members_if_group_expense = {member.id for member in group.members}
+
+    try:
+        # --- SPLIT METHOD LOGIC ---
+        if expense_in.split_method == schemas.SplitMethodEnum.EQUAL:
+            if not expense_in.selected_participant_user_ids:
+                raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail="selected_participant_user_ids is required for 'equal' split.")
+            if not expense_in.selected_participant_user_ids: # Should be caught by above, but defensive
+                 raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail="No participants selected for equal split.")
+
+            num_participants = len(expense_in.selected_participant_user_ids)
+            if num_participants == 0: # Explicitly check for empty list if it bypasses the None check
+                raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail="Participant list cannot be empty for equal split.")
+
+            individual_share = round(expense_in.amount / num_participants, 2) # Using 2 decimal places for currency
+
+            # Distribute remainder for precision
+            remainder = round(expense_in.amount - (individual_share * num_participants), 2)
+
+            seen_user_ids = set()
+            for i, user_id in enumerate(expense_in.selected_participant_user_ids):
+                await get_object_or_404(session, User, user_id, f"Participant user ID {user_id} not found.")
+                if group_members_if_group_expense and user_id not in group_members_if_group_expense:
+                    raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=f"Participant user ID {user_id} is not a member of the group.")
+                if user_id in seen_user_ids:
+                    raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=f"Duplicate user ID {user_id} in selected_participant_user_ids.")
+                seen_user_ids.add(user_id)
+
+                current_share = individual_share
+                if i == 0 and remainder != 0: # Add remainder to the first participant
+                    current_share = round(individual_share + remainder, 2)
+
+                participants_for_db.append({"user_id": user_id, "share_amount": current_share})
+
+        elif expense_in.split_method == schemas.SplitMethodEnum.PERCENTAGE:
+            if not expense_in.participant_shares:
+                raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail="participant_shares is required for 'percentage' split.")
+
+            total_percentage = 0.0
+            calculated_shares = []
+            seen_user_ids = set()
+
+            for share_detail in expense_in.participant_shares:
+                await get_object_or_404(session, User, share_detail.user_id, f"Participant user ID {share_detail.user_id} not found.")
+                if group_members_if_group_expense and share_detail.user_id not in group_members_if_group_expense:
+                    raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=f"Participant user ID {share_detail.user_id} is not a member of the group.")
+                if share_detail.user_id in seen_user_ids:
+                    raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=f"Duplicate user ID {share_detail.user_id} in participant shares.")
+                seen_user_ids.add(share_detail.user_id)
+
+                if not (0 < share_detail.share_amount <= 100): # Percentage must be > 0 and <= 100
+                     raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=f"Invalid percentage {share_detail.share_amount} for user {share_detail.user_id}. Must be between 0 (exclusive) and 100 (inclusive).")
+                total_percentage += share_detail.share_amount
+                calculated_shares.append({"user_id": share_detail.user_id, "percentage": share_detail.share_amount})
+
+            if abs(total_percentage - 100.0) > 1e-2: # Using tolerance for 100% check
+                raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=f"Percentages must sum up to 100. Current sum: {total_percentage:.2f}%.")
+
+            actual_sum_of_calculated_shares = 0.0
+            for i, cs in enumerate(calculated_shares):
+                share_value = round((cs["percentage"] / 100.0) * expense_in.amount, 2)
+                participants_for_db.append({"user_id": cs["user_id"], "share_amount": share_value})
+                actual_sum_of_calculated_shares += share_value
+
+            # Adjust for rounding differences against total expense amount
+            remainder = round(expense_in.amount - actual_sum_of_calculated_shares, 2)
+            if abs(remainder) > 1e-9 and participants_for_db: # If there's a non-negligible remainder
+                participants_for_db[0]["share_amount"] = round(participants_for_db[0]["share_amount"] + remainder, 2)
+
+
+        elif expense_in.split_method == schemas.SplitMethodEnum.UNEQUAL:
+            if not expense_in.participant_shares:
+                 # For 'unequal', if no shares provided, it implies payer takes all. This is handled later.
+                 # If shares are explicitly empty list [], that's an error for non-zero amount.
+                if expense_in.participant_shares == []: # Explicit empty list
+                    if abs(expense_in.amount) > 1e-9: # If amount is not zero
+                        raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail="Participant shares cannot be an empty list for 'unequal' split with non-zero amount.")
+                    # If amount is zero, empty list is fine, no participants.
+                # If None, then payer covers all. This is handled by the 'else' block after all split methods.
+
+            # This block processes if participant_shares is provided and not empty for 'unequal'
+            if expense_in.participant_shares: # Not None and not empty (empty list handled above)
+                seen_user_ids = set()
+                sum_of_shares = 0.0
+                for share_detail in expense_in.participant_shares:
+                    await get_object_or_404(session, User, share_detail.user_id, f"Participant user ID {share_detail.user_id} not found.")
+                    if group_members_if_group_expense and share_detail.user_id not in group_members_if_group_expense:
+                        raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=f"Participant user ID {share_detail.user_id} is not a member of the group.")
+                    if share_detail.user_id in seen_user_ids:
+                        raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=f"Duplicate user ID {share_detail.user_id} in participant shares.")
+                    seen_user_ids.add(share_detail.user_id)
+                    if share_detail.share_amount <= 1e-9: # Share must be positive
+                        raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=f"Share amount for user {share_detail.user_id} must be positive for 'unequal' split.")
+
+                    sum_of_shares += share_detail.share_amount
+                    participants_for_db.append({"user_id": share_detail.user_id, "share_amount": share_detail.share_amount})
+
+                if abs(sum_of_shares - expense_in.amount) > 1e-2:
+                    raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=f"Sum of participant shares ({sum_of_shares:.2f}) does not match total expense amount ({expense_in.amount:.2f}) for 'unequal' split.")
+
+        # Default case: If no specific split method processed shares, or if 'unequal' had no participant_shares (payer takes all)
+        if not participants_for_db:
+            if abs(expense_in.amount) > 1e-9: # If amount is not zero, payer is the sole participant
+                await get_object_or_404(session, User, payer_id, "Payer (for default participation) not found.")
+                participants_for_db.append({"user_id": payer_id, "share_amount": expense_in.amount})
+            # If amount is zero and no participants, it's fine. participants_for_db remains empty.
+
         # Create the Expense object
-        db_expense = Expense.model_validate(
-            expense_in, update={"paid_by_user_id": current_user.id}
-        )
+        expense_data_for_model = expense_in.model_dump(exclude={"split_method", "selected_participant_user_ids", "participant_shares"})
+        expense_data_for_model["paid_by_user_id"] = payer_id
+
+        # Store split_method and selected_participant_user_ids_json
+        expense_data_for_model["split_method"] = expense_in.split_method.value if expense_in.split_method else schemas.SplitMethodEnum.UNEQUAL.value
+        if expense_in.split_method == schemas.SplitMethodEnum.EQUAL and expense_in.selected_participant_user_ids:
+            expense_data_for_model["selected_participant_user_ids_json"] = json.dumps(expense_in.selected_participant_user_ids)
+        else:
+            expense_data_for_model["selected_participant_user_ids_json"] = None
+
+        db_expense = Expense(**expense_data_for_model)
         session.add(db_expense)
         await session.flush()  # Assigns an ID to db_expense
 
@@ -157,13 +263,65 @@ async def create_expense_endpoint(
     # Validate currency_id
     await get_object_or_404(session, Currency, expense_in.currency_id)
 
-    if expense_in.group_id:
-        await get_object_or_404(session, Group, expense_in.group_id)  # Check existence
+    # Determine the actual payer
+    payer_id = current_user.id
+    if expense_in.paid_by_user_id is not None:
+        payer_user = await get_object_or_404(session, User, expense_in.paid_by_user_id, "Payer user not found.")
+        payer_id = payer_user.id
 
-    db_expense = Expense.model_validate(
-        expense_in, update={"paid_by_user_id": current_user.id}
-    )
+    # Validate currency_id
+    await get_object_or_404(session, Currency, expense_in.currency_id)
+
+    # Validate group_id if provided and permissions
+    if expense_in.group_id:
+        group = await get_object_or_404(session, Group, expense_in.group_id, "Group not found.")
+        # Check if current_user (creator) is a member of the group
+        current_user_is_member = any(member.id == current_user.id for member in group.members)
+        if not current_user_is_member:
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="Creator must be a member of the group to add expenses.",
+            )
+
+        # If a specific payer is designated, check if that payer is also a member of the group
+        if expense_in.paid_by_user_id is not None and expense_in.paid_by_user_id != current_user.id:
+            payer_is_member = any(member.id == expense_in.paid_by_user_id for member in group.members)
+            if not payer_is_member:
+                raise HTTPException(
+                    status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                    detail="Designated payer is not a member of the group.",
+                )
+
+    # Create the Expense object, ensuring paid_by_user_id is set to the determined payer_id
+    # For this simple endpoint, participant_shares are not processed.
+    # The payer (payer_id) is implicitly the sole participant.
+    expense_data_for_model = expense_in.model_dump(exclude={"split_method", "selected_participant_user_ids", "participant_shares"})
+    expense_data_for_model["paid_by_user_id"] = payer_id
+
+    # For this simple endpoint, split_method is implicitly "unequal" and no specific selected_participant_user_ids.
+    expense_data_for_model["split_method"] = schemas.SplitMethodEnum.UNEQUAL.value
+    expense_data_for_model["selected_participant_user_ids_json"] = None
+
+    db_expense = Expense(**expense_data_for_model)
     session.add(db_expense)
+
+    # Add the payer as the sole participant
+    # This was missing previously if this endpoint is to truly represent a single-payer expense
+    # where the payer covers the whole amount.
+    # If participant_shares were allowed here, this would be more complex.
+    # Assuming this endpoint creates an expense where the payer_id is the only participant.
+    sole_participant = ExpenseParticipant(
+        expense_id=db_expense.id, # This will be set after flush
+        user_id=payer_id,
+        share_amount=db_expense.amount
+    )
+    # Need to flush to get db_expense.id before creating ExpenseParticipant
+    # Or, handle it similarly to create_expense_with_participants_endpoint
+
+    await session.flush() # Get expense ID
+    sole_participant.expense_id = db_expense.id # Set it now
+    session.add(sole_participant)
+
     await session.commit()
     await session.refresh(db_expense)
 
@@ -172,6 +330,7 @@ async def create_expense_endpoint(
         select(Expense)
         .where(Expense.id == db_expense.id)
         .options(selectinload(Expense.currency), selectinload(Expense.paid_by))
+        # Participants will be loaded by _get_expense_read_details
     )
     result = await session.exec(stmt)
     refreshed_db_expense = result.one_or_none()
@@ -182,8 +341,6 @@ async def create_expense_endpoint(
             detail="Failed to re-fetch expense after creation with full details",
         )
 
-    # Manually construct and return ExpenseRead with participant_details
-    # For simple creation, participants are not added here, so participant_details will be empty.
     return await _get_expense_read_details(
         session=session, db_expense=refreshed_db_expense
     )
@@ -784,5 +941,146 @@ async def _get_expense_read_details(
         "currency_id": db_expense.currency_id,
         "currency": currency_for_schema,
         "participant_details": participant_details_list,
+        "receipt_image_url": db_expense.receipt_image_url, # Added
+        "split_method": schemas.SplitMethodEnum(db_expense.split_method) if db_expense.split_method else None, # Added
+        "selected_participant_user_ids": json.loads(db_expense.selected_participant_user_ids_json) if db_expense.selected_participant_user_ids_json else None, # Added
     }
     return schemas.ExpenseRead.model_validate(expense_read_data)
+
+
+# Additional imports for receipt upload
+import shutil
+import os
+import uuid
+from fastapi import UploadFile, File
+
+# Define upload directory relative to app root
+UPLOAD_DIR_RECEIPTS = "uploads/receipts"
+# Ensure UPLOAD_DIR_RECEIPTS is created if it doesn't exist when the app starts.
+# This can be done in main.py or here using a startup event if complex,
+# or simply by checking and creating in the endpoint for simplicity here.
+
+@router.post("/{expense_id}/upload-receipt", response_model=schemas.ExpenseRead)
+async def upload_expense_receipt_endpoint(
+    *,
+    session: AsyncSession = Depends(get_session),
+    expense_id: int,
+    file: UploadFile = File(...),
+    current_user: User = Depends(get_current_user),
+):
+    db_expense = await session.get(
+        Expense,
+        expense_id,
+        options=[
+            selectinload(Expense.paid_by),
+            selectinload(Expense.group).selectinload(Group.members),
+        ],
+    )
+
+    if not db_expense:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Expense not found")
+
+    # Authorization: Current user must be the payer or a member of the group if it's a group expense.
+    # More granular: could be creator, or involved participant. For now, payer or group member.
+    is_payer = db_expense.paid_by_user_id == current_user.id
+    is_group_member_of_expense_group = False
+    if db_expense.group:
+        is_group_member_of_expense_group = any(member.id == current_user.id for member in db_expense.group.members)
+
+    if not (is_payer or is_group_member_of_expense_group):
+        # If not a group expense, only payer can upload.
+        if not db_expense.group and not is_payer:
+             raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Not authorized to upload receipt for this expense.")
+        # If it is a group expense, and user is neither payer nor member.
+        if db_expense.group and not (is_payer or is_group_member_of_expense_group):
+             raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Not authorized to upload receipt for this group expense.")
+
+
+    # Basic file validation (content type and size)
+    if file.content_type not in ["image/jpeg", "image/png", "image/gif"]:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Invalid file type. Only JPG, PNG, GIF allowed.")
+
+    # Size limit (e.g., 5MB)
+    # file.file is a SpooledTemporaryFile. We can check its size.
+    # To get actual size, we need to read it or seek to end.
+    # file.file.seek(0, os.SEEK_END)
+    # file_size = file.file.tell()
+    # file.file.seek(0) # Reset cursor
+    # if file_size > 5 * 1024 * 1024: # 5MB
+    #     raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="File size exceeds 5MB limit.")
+
+
+    # Create unique filename and path
+    # Ensure the root UPLOAD_DIR_RECEIPTS exists (important for first upload)
+    # The path stored in DB should be relative to where static files are served from.
+    # e.g. if static files served from "static/", and uploads go to "static/receipts/", then URL is "receipts/filename.ext"
+
+    # For local dev, let's assume UPLOAD_DIR_RECEIPTS is directly under 'app' or project root,
+    # and FastAPI will serve it from a path like /static/receipts.
+    # So, the path stored in DB will be "receipts/unique_filename.ext"
+
+    # Correctly create the uploads directory if it doesn't exist relative to the script's execution path (app root)
+    # This assumes the script runs from the project root where 'app' is a subdir.
+    # If running from 'app' dir, then UPLOAD_DIR_RECEIPTS should be relative to 'app'.
+    # Given `cd app` is used, paths are relative to `/app` directory.
+
+    # Base directory for uploads within the 'app' directory
+    # This means uploads will be in 'app/uploads/receipts'
+    # Static serving should be configured for 'app/uploads' or 'app/uploads/receipts' later.
+
+    # The UPLOAD_DIR_RECEIPTS = "uploads/receipts" is relative to where the app is running from.
+    # If main.py is in app/src, and we are in app/ CWD, then this path is app/uploads/receipts.
+
+    # Let's ensure the full absolute path for os.makedirs
+    # This should be relative to the project root, not the script file.
+    # For the sandbox, assuming current working directory is /app
+
+    # Path for storing files: app/uploads/receipts
+    # Path for URL: /uploads/receipts/filename.ext (if /uploads is served as static)
+
+    # Simplified: Assume UPLOAD_DIR_RECEIPTS is relative to the app's root (where main.py is, usually app/src or app/)
+    # For safety, let's make it relative to the current file's directory structure if possible, or use absolute paths for clarity.
+    # However, for deployment, relative paths from a known root are better.
+    # Let's assume 'uploads' is at the same level as 'src' inside 'app'.
+    # So, if expenses.py is in app/src/routers, then path is ../../uploads/receipts
+
+    # Given the project structure, 'app' is the root for backend.
+    # So, 'app/uploads/receipts' seems correct.
+
+    # Create the directory path
+    # The path should be formed from a known base, like the app's root directory.
+    # For the tool environment, `os.getcwd()` when `cd app` has been run is `/app`.
+    # So, `os.path.join(os.getcwd(), UPLOAD_DIR_RECEIPTS)` would be `/app/uploads/receipts`.
+
+    upload_dir_full_path = os.path.join(os.getcwd(), UPLOAD_DIR_RECEIPTS) # os.getcwd() is /app here
+    os.makedirs(upload_dir_full_path, exist_ok=True)
+
+    _, extension = os.path.splitext(file.filename)
+    unique_filename = f"{uuid.uuid4()}{extension}"
+    file_location = os.path.join(upload_dir_full_path, unique_filename)
+
+    # Save the file
+    try:
+        with open(file_location, "wb+") as file_object:
+            shutil.copyfileobj(file.file, file_object)
+    except Exception as e:
+        # Log error e
+        raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=f"Could not save file: {str(e)}")
+    finally:
+        file.file.close() # Ensure file is closed
+
+    # Store relative path for URL (e.g., "/uploads/receipts/filename.ext" or "receipts/filename.ext")
+    # This depends on how static files will be mounted.
+    # If FastAPI serves a directory named "uploads_mounted_statically" which points to "app/uploads",
+    # then the URL would be "/uploads_mounted_statically/receipts/unique_filename.ext"
+    # For simplicity, let's store the path relative from "uploads" dir.
+    # So, "receipts/unique_filename.ext". The static mount point will handle the "uploads" part.
+    relative_file_path = os.path.join(UPLOAD_DIR_RECEIPTS.split('/')[-1], unique_filename) # e.g. "receipts/filename.ext"
+
+
+    db_expense.receipt_image_url = relative_file_path
+    session.add(db_expense)
+    await session.commit()
+    await session.refresh(db_expense)
+
+    return await _get_expense_read_details(session=session, db_expense=db_expense)

--- a/app/tests/test_expense_receipts.py
+++ b/app/tests/test_expense_receipts.py
@@ -1,0 +1,169 @@
+import pytest
+import pytest_asyncio
+from httpx import AsyncClient
+from fastapi import status, UploadFile
+from typing import Dict, Any, AsyncGenerator, IO
+import io
+import os # For UPLOAD_DIR_RECEIPTS access if needed for cleanup or path construction
+
+from src.models.models import User, Group, Currency, Expense
+from src.main import app # For UPLOAD_DIR_RECEIPTS if defined there, or define locally for test
+
+# Assuming UPLOAD_DIR_RECEIPTS is defined in expenses router or main app
+# For testing, we might need to know this path to check file existence or clean up.
+# Let's define it here based on what was used in expenses.py for consistency.
+# CWD for tests is /app
+TEST_UPLOAD_DIR = "uploads/receipts"
+
+
+@pytest.mark.asyncio
+async def test_upload_receipt_success_payer(
+    client: AsyncClient,
+    normal_user_token_headers: dict[str, str], # Payer's headers
+    test_user: User, # Payer
+    test_currency: Currency,
+):
+    # 1. Create an expense
+    expense_payload = {
+        "description": "Expense for receipt",
+        "amount": 50.0,
+        "currency_id": test_currency.id,
+        "paid_by_user_id": test_user.id,
+        "split_method": "unequal",
+    }
+    response_create = await client.post("/api/v1/expenses/service/", json=expense_payload, headers=normal_user_token_headers)
+    assert response_create.status_code == status.HTTP_201_CREATED
+    expense_id = response_create.json()["id"]
+
+    # 2. Upload a receipt
+    # Create a dummy file for upload
+    dummy_file_content = b"fake image data"
+    files = {"file": ("receipt.jpg", io.BytesIO(dummy_file_content), "image/jpeg")}
+
+    response_upload = await client.post(f"/api/v1/expenses/{expense_id}/upload-receipt", files=files, headers=normal_user_token_headers)
+    assert response_upload.status_code == status.HTTP_200_OK, f"Upload failed: {response_upload.text}"
+
+    data = response_upload.json()
+    assert data["id"] == expense_id
+    assert data["receipt_image_url"] is not None
+    assert data["receipt_image_url"].startswith("receipts/")
+    assert data["receipt_image_url"].endswith(".jpg")
+
+    # Optional: Verify file exists on server (requires knowing the exact path and access)
+    # file_path_on_server = os.path.join(os.getcwd(), TEST_UPLOAD_DIR, data["receipt_image_url"].split('/')[-1])
+    # assert os.path.exists(file_path_on_server)
+    # Cleanup: os.remove(file_path_on_server) # Requires careful handling
+
+@pytest.mark.asyncio
+async def test_upload_receipt_success_group_member(
+    client: AsyncClient,
+    normal_user_token_headers: dict[str, str], # Payer (test_user)
+    test_user: User,
+    test_user_2_with_token: dict, # Group member who is not payer
+    test_group_shared_with_user2: Group, # Group with test_user and test_user_2
+    test_currency: Currency,
+):
+    # 1. Create a group expense paid by test_user
+    expense_payload = {
+        "description": "Group expense for receipt",
+        "amount": 60.0,
+        "currency_id": test_currency.id,
+        "group_id": test_group_shared_with_user2.id,
+        "paid_by_user_id": test_user.id, # test_user is payer
+        "split_method": "equal",
+        "selected_participant_user_ids": [test_user.id, test_user_2_with_token["user"].id]
+    }
+    response_create = await client.post("/api/v1/expenses/service/", json=expense_payload, headers=normal_user_token_headers)
+    assert response_create.status_code == status.HTTP_201_CREATED
+    expense_id = response_create.json()["id"]
+
+    # 2. test_user_2 (group member, not payer) uploads receipt
+    group_member_headers = test_user_2_with_token["headers"]
+    dummy_file_content = b"group member image data"
+    files = {"file": ("receipt_group.png", io.BytesIO(dummy_file_content), "image/png")}
+
+    response_upload = await client.post(f"/api/v1/expenses/{expense_id}/upload-receipt", files=files, headers=group_member_headers)
+    assert response_upload.status_code == status.HTTP_200_OK, f"Upload failed: {response_upload.text}"
+    data = response_upload.json()
+    assert data["receipt_image_url"] is not None
+    assert data["receipt_image_url"].startswith("receipts/")
+    assert data["receipt_image_url"].endswith(".png")
+
+@pytest.mark.asyncio
+async def test_upload_receipt_fail_non_involved_user(
+    client: AsyncClient,
+    normal_user_token_headers: dict[str, str], # Payer (test_user)
+    test_user: User,
+    test_user_3_with_token: dict, # Non-involved user
+    test_currency: Currency,
+):
+    # 1. Create an expense by test_user
+    expense_payload = {
+        "description": "Expense for auth test",
+        "amount": 30.0,
+        "currency_id": test_currency.id,
+        "paid_by_user_id": test_user.id,
+        "split_method": "unequal",
+    }
+    response_create = await client.post("/api/v1/expenses/service/", json=expense_payload, headers=normal_user_token_headers)
+    assert response_create.status_code == status.HTTP_201_CREATED
+    expense_id = response_create.json()["id"]
+
+    # 2. test_user_3 (non-involved) tries to upload
+    non_involved_user_headers = test_user_3_with_token["headers"]
+    files = {"file": ("receipt_auth_fail.jpg", io.BytesIO(b"some data"), "image/jpeg")}
+    response_upload = await client.post(f"/api/v1/expenses/{expense_id}/upload-receipt", files=files, headers=non_involved_user_headers)
+    assert response_upload.status_code == status.HTTP_403_FORBIDDEN
+
+@pytest.mark.asyncio
+async def test_upload_receipt_fail_expense_not_found(
+    client: AsyncClient, normal_user_token_headers: dict[str, str]
+):
+    non_existent_expense_id = 999999
+    files = {"file": ("receipt_notfound.jpg", io.BytesIO(b"some data"), "image/jpeg")}
+    response_upload = await client.post(f"/api/v1/expenses/{non_existent_expense_id}/upload-receipt", files=files, headers=normal_user_token_headers)
+    assert response_upload.status_code == status.HTTP_404_NOT_FOUND
+
+@pytest.mark.asyncio
+async def test_upload_receipt_fail_invalid_file_type(
+    client: AsyncClient,
+    normal_user_token_headers: dict[str, str],
+    test_user: User,
+    test_currency: Currency,
+):
+    # 1. Create an expense
+    expense_payload = { "description": "File type test", "amount": 10.0, "currency_id": test_currency.id, "paid_by_user_id": test_user.id }
+    response_create = await client.post("/api/v1/expenses/service/", json=expense_payload, headers=normal_user_token_headers)
+    assert response_create.status_code == status.HTTP_201_CREATED
+    expense_id = response_create.json()["id"]
+
+    # 2. Upload an invalid file type
+    files = {"file": ("receipt.txt", io.BytesIO(b"this is not an image"), "text/plain")}
+    response_upload = await client.post(f"/api/v1/expenses/{expense_id}/upload-receipt", files=files, headers=normal_user_token_headers)
+    assert response_upload.status_code == status.HTTP_400_BAD_REQUEST
+    assert "Invalid file type" in response_upload.json()["detail"]
+
+# TODO: Add test for file size limit if implemented.
+# TODO: Consider testing if the file URL is actually accessible (might require more setup or a different testing approach for static files).
+# For now, checking the format of `receipt_image_url` is a good start.
+# Cleanup of uploaded files: This test suite doesn't automatically clean up files from TEST_UPLOAD_DIR.
+# In a real CI/CD, the test environment is usually ephemeral, or specific cleanup scripts are run.
+# For local testing, manual cleanup of `app/uploads/receipts` might be needed.
+# One could add a fixture to clean this directory before/after test session if it becomes an issue.
+# Example cleanup fixture (session-scoped):
+# @pytest_asyncio.fixture(scope="session", autouse=True)
+# async def cleanup_receipts_folder():
+#     # Before tests run (optional, if starting clean is desired)
+#     # if os.path.exists(TEST_UPLOAD_DIR):
+#     #     shutil.rmtree(TEST_UPLOAD_DIR)
+#     # os.makedirs(TEST_UPLOAD_DIR, exist_ok=True)
+#     yield
+#     # After all tests in session run
+#     if os.path.exists(TEST_UPLOAD_DIR):
+#         shutil.rmtree(TEST_UPLOAD_DIR) # Careful with this in real projects
+#         # print(f"Cleaned up {TEST_UPLOAD_DIR}")
+
+# For now, I will not add the auto-cleanup fixture to avoid accidental deletion
+# if paths are misconfigured or if someone runs tests outside a fully controlled environment.
+# The test environment itself should be responsible for its state.
+# The use of UUIDs for filenames minimizes collision risks.

--- a/app/tests/test_expenses.py
+++ b/app/tests/test_expenses.py
@@ -98,18 +98,19 @@ async def test_create_expense_with_currency_auth(
     assert data["amount"] == expense_data["amount"]
     assert data["id"] is not None
     assert "participant_details" in data
-    for pd_item in data[
-        "participant_details"
-    ]:  # Assuming it's an empty list for simple expense
-        assert "id" in pd_item  # ExpenseParticipant.id
-        assert pd_item.get("settled_transaction_id") is None
-        assert pd_item.get("settled_amount_in_transaction_currency") is None
-        assert pd_item.get("settled_currency_id") is None
-        assert pd_item.get("settled_currency") is None
+    # For simple endpoint, payer becomes sole participant
+    assert len(data["participant_details"]) == 1
+    assert data["participant_details"][0]["user"]["id"] == normal_user.id
+    assert data["participant_details"][0]["share_amount"] == expense_data["amount"]
+
     assert data["currency"] is not None
     assert data["currency"]["id"] == test_currency.id
     assert data["currency"]["code"] == test_currency.code
     assert data["currency"]["name"] == test_currency.name
+
+    assert data["receipt_image_url"] is None
+    assert data["split_method"] == "unequal" # Default for simple endpoint
+    assert data["selected_participant_user_ids"] is None
 
 
 @pytest.mark.asyncio
@@ -166,29 +167,32 @@ async def test_read_expense_authorization(
     other_user_token = res_other.json()["access_token"]
     other_user_headers = {"Authorization": f"Bearer {other_user_token}"}
 
-    # Setup: Create an expense by normal_user with other_user as a participant
+    # Setup: Create an expense by normal_user with other_user as a participant using "equal" split
+    expense_description = "Shared Dinner Equal Split"
+    expense_amount = 120.0
+    selected_participants = [normal_user.id, other_user_id]
     expense_payload = {
-        "expense_in": {
-            "description": "Shared Dinner",
-            "amount": 120.0,
-            "currency_id": test_currency.id,
-            # paid_by_user_id is implicit from normal_user_token_headers
-        },
-        "participant_user_ids": [
-            normal_user.id,
-            other_user_id,
-        ],  # Payer (normal_user) is also a participant
+        "description": expense_description,
+        "amount": expense_amount,
+        "currency_id": test_currency.id,
+        # paid_by_user_id is implicit (normal_user)
+        "split_method": "equal",
+        "selected_participant_user_ids": selected_participants,
     }
     response_create_exp = await client.post(
         "/api/v1/expenses/service/",
         json=expense_payload,
         headers=normal_user_token_headers,
     )
-    assert (
-        response_create_exp.status_code == status.HTTP_201_CREATED
-    )  # Changed from 200 OK
+    assert response_create_exp.status_code == status.HTTP_201_CREATED, f"Failed to create expense: {response_create_exp.text}"
     created_expense = response_create_exp.json()
     expense_id = created_expense["id"]
+
+    # Expected values for the created expense
+    assert created_expense["receipt_image_url"] is None
+    assert created_expense["split_method"] == "equal"
+    assert sorted(created_expense["selected_participant_user_ids"]) == sorted(selected_participants)
+
 
     # Test: Payer (normal_user) can view
     response_payer_view = await client.get(
@@ -196,17 +200,16 @@ async def test_read_expense_authorization(
     )
     assert response_payer_view.status_code == status.HTTP_200_OK
     payer_view_data = response_payer_view.json()
-    assert (
-        payer_view_data["description"] == expense_payload["expense_in"]["description"]
-    )
+    assert payer_view_data["description"] == expense_description
     assert payer_view_data["currency"] is not None
     assert payer_view_data["currency"]["id"] == test_currency.id
+    assert payer_view_data["receipt_image_url"] is None
+    assert payer_view_data["split_method"] == "equal"
+    assert sorted(payer_view_data["selected_participant_user_ids"]) == sorted(selected_participants)
+    assert len(payer_view_data["participant_details"]) == 2
     for pd_item in payer_view_data["participant_details"]:
         assert "id" in pd_item and isinstance(pd_item["id"], int)
-        assert pd_item.get("settled_transaction_id") is None
-        assert pd_item.get("settled_amount_in_transaction_currency") is None
-        assert pd_item.get("settled_currency_id") is None
-        assert pd_item.get("settled_currency") is None
+        assert pd_item.get("settled_transaction_id") is None # Keep existing checks
 
     # Test: Participant (other_user) can view
     response_participant_view = await client.get(
@@ -216,11 +219,14 @@ async def test_read_expense_authorization(
     participant_view_data = response_participant_view.json()
     assert participant_view_data["currency"] is not None
     assert participant_view_data["currency"]["id"] == test_currency.id
-    for pd_item in participant_view_data[
-        "participant_details"
-    ]:  # Check participant details in participant view
+    assert participant_view_data["receipt_image_url"] is None
+    assert participant_view_data["split_method"] == "equal"
+    assert sorted(participant_view_data["selected_participant_user_ids"]) == sorted(selected_participants)
+    assert len(participant_view_data["participant_details"]) == 2
+    for pd_item in participant_view_data["participant_details"]:
         assert "id" in pd_item and isinstance(pd_item["id"], int)
-        assert pd_item.get("settled_transaction_id") is None
+        assert pd_item.get("settled_transaction_id") is None # Keep existing checks
+
 
     # Test: Non-participant/non-payer/non-admin (third_user) cannot view (403)
     response_third_user_view = await client.get(
@@ -307,19 +313,24 @@ async def test_create_service_expense_success_auth(
         "srv_part1_auth",
         "srv_part1_auth@example.com",  # Uses helper
     )
+    participant1_data = await create_test_user(
+        client,
+        "srv_part1_auth",
+        "srv_part1_auth@example.com",
+    )
     participant1_id = participant1_data["id"]
 
+    expense_description = "Dinner via Service Auth Equal Split"
+    expense_amount = 100.0
+    selected_participants = [normal_user.id, participant1_id]
+
     service_expense_payload = {
-        "expense_in": {
-            "description": "Dinner via Service Auth",
-            "amount": 100.0,
-            "currency_id": test_currency.id,
-            # paid_by_user_id implicit from normal_user_token_headers
-        },
-        "participant_user_ids": [
-            normal_user.id,
-            participant1_id,
-        ],  # Payer is also a participant
+        "description": expense_description,
+        "amount": expense_amount,
+        "currency_id": test_currency.id,
+        "split_method": "equal",
+        "selected_participant_user_ids": selected_participants,
+        # paid_by_user_id is implicit (normal_user)
     }
     response = await client.post(
         "/api/v1/expenses/service/",
@@ -330,26 +341,23 @@ async def test_create_service_expense_success_auth(
         f"Failed to create service expense: {response.text}"
     )
     data = response.json()
-    assert data["description"] == service_expense_payload["expense_in"]["description"]
+    assert data["description"] == expense_description
     assert data["id"] is not None
-    assert len(data["participant_details"]) == len(
-        service_expense_payload["participant_user_ids"]
-    )
+    assert data["receipt_image_url"] is None
+    assert data["split_method"] == "equal"
+    assert sorted(data["selected_participant_user_ids"]) == sorted(selected_participants)
+
+    assert len(data["participant_details"]) == len(selected_participants)
     for pd_item in data["participant_details"]:
         assert "id" in pd_item and isinstance(pd_item["id"], int)
-        assert pd_item.get("settled_transaction_id") is None  # Check new fields
+        assert pd_item.get("settled_transaction_id") is None
         assert pd_item.get("settled_amount_in_transaction_currency") is None
         assert pd_item.get("settled_currency_id") is None
         assert pd_item.get("settled_currency") is None
-        # Check user details within participant_details
         assert "user" in pd_item
         assert "id" in pd_item["user"]
-        # Example: ensure correct users are listed if participant_user_ids is used for matching
         user_id_in_participant_detail = pd_item["user"]["id"]
-        assert (
-            user_id_in_participant_detail
-            in service_expense_payload["participant_user_ids"]
-        )
+        assert user_id_in_participant_detail in selected_participants
 
     assert data["currency"] is not None
     assert data["currency"]["id"] == test_currency.id
@@ -389,21 +397,23 @@ async def test_read_multiple_expenses_auth(
         )
         if found_expense_in_list:
             assert found_expense_in_list["currency"]["id"] == test_currency.id
-            # Since this expense was simple, participant_details might be empty or just the payer
-            # depending on how POST /expenses/ (simple) vs POST /expenses/service/ works regarding auto-participation.
-            # The key is that the fields are present, even if None.
-            for pd_item in found_expense_in_list.get("participant_details", []):
-                assert "id" in pd_item and isinstance(pd_item["id"], int)
-                assert pd_item.get("settled_transaction_id") is None
-                assert pd_item.get("settled_amount_in_transaction_currency") is None
-                assert pd_item.get("settled_currency_id") is None
-                assert pd_item.get("settled_currency") is None
+            assert found_expense_in_list["receipt_image_url"] is None
+            assert found_expense_in_list["split_method"] == "unequal" # Simple endpoint defaults to this
+            assert found_expense_in_list["selected_participant_user_ids"] is None
+
+            # For simple endpoint, payer is sole participant
+            assert len(found_expense_in_list["participant_details"]) == 1
+            pd_item = found_expense_in_list["participant_details"][0]
+            assert "id" in pd_item and isinstance(pd_item["id"], int)
+            assert pd_item.get("settled_transaction_id") is None
+            assert pd_item.get("settled_amount_in_transaction_currency") is None
+            assert pd_item.get("settled_currency_id") is None
+            assert pd_item.get("settled_currency") is None
+            assert pd_item["user"]["id"] == normal_user.id # normal_user created and paid
+            assert pd_item["share_amount"] == created_expense_data["amount"]
         else:
-            # If the created expense is not found, it implies an issue with how expenses are listed for the user
-            # or the user context of the test. For now, we'll assume it might be found.
-            # A more robust test would ensure the user creating the expense is the one listing,
-            # or that the listing logic correctly filters for this user.
-            pass
+            # This case should ideally not happen if the listing logic is correct for the user
+            pytest.fail("Created expense not found in the list for the user who created it.")
 
 
 # Updating expenses (PUT /api/v1/expenses/{expense_id}) is protected by get_current_user.
@@ -449,15 +459,23 @@ async def test_update_expense_success_auth(
     assert data["description"] == "Updated Desc Auth"
     assert data["amount"] == 75.0
     assert data["id"] == expense_id
-    assert (
-        "participant_details" in data
-    )  # Should be empty if no participants were added on creation/update
-    for pd_item in data["participant_details"]:
-        assert "id" in pd_item and isinstance(pd_item["id"], int)
-        assert pd_item.get("settled_transaction_id") is None
-        assert pd_item.get("settled_amount_in_transaction_currency") is None
-        assert pd_item.get("settled_currency_id") is None
-        assert pd_item.get("settled_currency") is None
+
+    assert data["receipt_image_url"] is None
+    # split_method and selected_participant_user_ids might depend on how update handles them
+    # Assuming update doesn't change split_method unless participants are also updated.
+    # The original expense was simple, so it was "unequal".
+    assert data["split_method"] == "unequal"
+    assert data["selected_participant_user_ids"] is None
+
+    # If only amount/desc/currency changes, participants might be recalculated or remain.
+    # The current update logic recalculates shares for existing participants if amount changes and no new participant list is given.
+    # For a simple expense, the payer was the only participant.
+    assert "participant_details" in data
+    assert len(data["participant_details"]) == 1
+    pd_item = data["participant_details"][0]
+    assert pd_item["user"]["id"] == normal_user.id # Payer
+    assert pd_item["share_amount"] == 75.0 # New amount
+
     assert data["currency"] is not None
     assert data["currency"]["id"] == new_currency_id
     assert data["currency"]["code"] == "UCU"
@@ -511,16 +529,20 @@ async def test_create_expense_with_custom_shares_success(
         "description": "Custom Shares Test",
         "amount": expense_amount,
         "currency_id": test_currency.id,
+        "split_method": "unequal", # Explicitly set for this test
         "participant_shares": shares,
     }
     response = await client.post(
         "/api/v1/expenses/service/", json=expense_payload, headers=normal_user_token_headers
     )
-    assert response.status_code == status.HTTP_201_CREATED
+    assert response.status_code == status.HTTP_201_CREATED, f"Failed: {response.text}"
     data = response.json()
     assert data["amount"] == expense_amount
     assert data["description"] == "Custom Shares Test"
     assert data["currency"]["id"] == test_currency.id
+    assert data["receipt_image_url"] is None
+    assert data["split_method"] == "unequal"
+    assert data["selected_participant_user_ids"] is None # Not applicable for unequal
 
     participant_details = data["participant_details"]
     assert len(participant_details) == 2
@@ -545,6 +567,7 @@ async def test_create_expense_custom_shares_sum_mismatch(
         "description": "Sum Mismatch",
         "amount": 100.0,
         "currency_id": test_currency.id,
+        "split_method": "unequal",
         "participant_shares": [
             {"user_id": test_user.id, "share_amount": 50.0},
             {"user_id": test_user_2.id, "share_amount": 40.0}, # Sums to 90.0
@@ -568,6 +591,7 @@ async def test_create_expense_custom_shares_invalid_user(
         "description": "Invalid User Share",
         "amount": 100.0,
         "currency_id": test_currency.id,
+        "split_method": "unequal",
         "participant_shares": [
             {"user_id": test_user.id, "share_amount": 50.0},
             {"user_id": invalid_user_id, "share_amount": 50.0},
@@ -591,6 +615,7 @@ async def test_create_expense_custom_shares_duplicate_user(
         "description": "Duplicate User Share",
         "amount": 100.0,
         "currency_id": test_currency.id,
+        "split_method": "unequal",
         "participant_shares": [
             {"user_id": test_user.id, "share_amount": 50.0},
             {"user_id": test_user.id, "share_amount": 50.0},
@@ -611,46 +636,48 @@ async def test_create_expense_no_custom_shares_payer_is_sole_participant(
 ):
     expense_amount = 75.0
     expense_payload = {
-        "description": "Payer Only Expense",
+        "description": "Payer Only Expense (Unequal, No Shares)",
         "amount": expense_amount,
         "currency_id": test_currency.id,
-        "participant_shares": None, # Explicitly None
+        "split_method": "unequal", # Explicit or rely on default
+        "participant_shares": None,
     }
     response = await client.post(
         "/api/v1/expenses/service/", json=expense_payload, headers=normal_user_token_headers
     )
-    assert response.status_code == status.HTTP_201_CREATED
+    assert response.status_code == status.HTTP_201_CREATED, f"Failed: {response.text}"
     data = response.json()
     assert data["amount"] == expense_amount
+    assert data["receipt_image_url"] is None
+    assert data["split_method"] == "unequal"
+    assert data["selected_participant_user_ids"] is None
+
     participant_details = data["participant_details"]
     assert len(participant_details) == 1
-    assert participant_details[0]["user"]["id"] == test_user.id # normal_user is the current_user
+    assert participant_details[0]["user"]["id"] == test_user.id
     assert participant_details[0]["share_amount"] == expense_amount
 
 @pytest.mark.asyncio
-async def test_create_expense_empty_custom_shares_list_payer_is_sole_participant(
+async def test_create_expense_unequal_empty_shares_list_error( # Renamed and logic changed
     client: AsyncClient,
     normal_user_token_headers: dict[str, str],
-    test_user: User, # Payer
+    test_user: User,
     test_currency: Currency,
 ):
     expense_amount = 88.0
     expense_payload = {
-        "description": "Empty Shares List Expense",
-        "amount": expense_amount,
+        "description": "Empty Shares List Error Test",
+        "amount": expense_amount, # Non-zero amount
         "currency_id": test_currency.id,
+        "split_method": "unequal",
         "participant_shares": [], # Empty list
     }
     response = await client.post(
         "/api/v1/expenses/service/", json=expense_payload, headers=normal_user_token_headers
     )
-    assert response.status_code == status.HTTP_201_CREATED
-    data = response.json()
-    assert data["amount"] == expense_amount
-    participant_details = data["participant_details"]
-    assert len(participant_details) == 1
-    assert participant_details[0]["user"]["id"] == test_user.id
-    assert participant_details[0]["share_amount"] == expense_amount
+    # Expected behavior: error because participant_shares is empty for non-zero amount with "unequal"
+    assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+    assert "Participant shares cannot be an empty list for 'unequal' split with non-zero amount" in response.json()["detail"]
 
 
 # III. Tests for Expense Update (PUT /api/v1/expenses/{expense_id})
@@ -673,6 +700,7 @@ async def create_initial_expense_for_update(
         "description": "Initial Expense for Update",
         "amount": initial_amount,
         "currency_id": currency_id,
+        "split_method": "unequal", # Assuming default for these tests
         "participant_shares": participants,
     }
     response = await client.post(
@@ -708,10 +736,13 @@ async def test_update_expense_change_amount_and_custom_shares_success(
     response = await client.put(
         f"/api/v1/expenses/{expense_id}", json=update_payload, headers=normal_user_token_headers
     )
-    assert response.status_code == status.HTTP_200_OK
+    assert response.status_code == status.HTTP_200_OK, f"Failed: {response.text}"
     data = response.json()
     assert data["amount"] == updated_amount
     assert data["description"] == "Updated Amount and Shares"
+    assert data["receipt_image_url"] is None
+    assert data["split_method"] == "unequal" # Original was unequal, not changed by this update type
+    assert data["selected_participant_user_ids"] is None
 
     participant_details = data["participant_details"]
     assert len(participant_details) == 2
@@ -776,9 +807,13 @@ async def test_update_expense_change_amount_only_recalculate_equal_shares(
     response = await client.put(
         f"/api/v1/expenses/{expense_id}", json=update_payload, headers=normal_user_token_headers
     )
-    assert response.status_code == status.HTTP_200_OK
+    assert response.status_code == status.HTTP_200_OK, f"Failed: {response.text}"
     data = response.json()
     assert data["amount"] == new_total_amount
+    assert data["receipt_image_url"] is None
+    assert data["split_method"] == "unequal" # Original method was unequal
+    assert data["selected_participant_user_ids"] is None
+
 
     participant_details = data["participant_details"]
     assert len(participant_details) == 2 # Should still be 2 participants
@@ -841,8 +876,12 @@ async def test_update_expense_auth_payer_can_update(
     response = await client.put(
         f"/api/v1/expenses/{expense_id}", json=update_payload, headers=normal_user_token_headers
     )
-    assert response.status_code == status.HTTP_200_OK
-    assert response.json()["description"] == "Payer Updated"
+    assert response.status_code == status.HTTP_200_OK, f"Failed: {response.text}"
+    data = response.json()
+    assert data["description"] == "Payer Updated"
+    assert data["receipt_image_url"] is None
+    assert data["split_method"] == "unequal" # Original was unequal
+    assert data["selected_participant_user_ids"] is None
 
 @pytest.mark.asyncio
 async def test_update_expense_auth_other_user_cannot_update_non_group_non_participant(
@@ -890,8 +929,12 @@ async def test_update_expense_auth_participant_can_update_non_group(
     response = await client.put(
         f"/api/v1/expenses/{expense_id}", json=update_payload, headers=participant_headers
     )
-    assert response.status_code == status.HTTP_200_OK
-    assert response.json()["description"] == "Updated by Participant"
+    assert response.status_code == status.HTTP_200_OK, f"Failed: {response.text}"
+    data = response.json()
+    assert data["description"] == "Updated by Participant"
+    assert data["receipt_image_url"] is None
+    assert data["split_method"] == "unequal"
+    assert data["selected_participant_user_ids"] is None
 
 @pytest.mark.asyncio
 async def test_update_expense_auth_group_member_can_update_group_expense(
@@ -929,5 +972,338 @@ async def test_update_expense_auth_group_member_can_update_group_expense(
     response = await client.put(
         f"/api/v1/expenses/{expense_id}", json=update_payload, headers=group_member_headers
     )
-    assert response.status_code == status.HTTP_200_OK
-    assert response.json()["description"] == "Updated by Group Member"
+    assert response.status_code == status.HTTP_200_OK, f"Failed: {response.text}"
+    data = response.json()
+    assert data["description"] == "Updated by Group Member"
+    assert data["receipt_image_url"] is None
+    assert data["split_method"] == "unequal" # Initial creation was unequal
+    assert data["selected_participant_user_ids"] is None
+
+
+# V. Tests for Payer Selection
+@pytest.mark.asyncio
+async def test_create_expense_designate_self_as_payer(
+    client: AsyncClient,
+    normal_user_token_headers: dict[str, str],
+    test_user: User,
+    test_currency: Currency,
+):
+    expense_payload = {
+        "description": "Self Payer Test",
+        "amount": 50.0,
+        "currency_id": test_currency.id,
+        "paid_by_user_id": test_user.id, # Designating self
+        "split_method": "unequal", # Payer is sole participant by default if no shares
+    }
+    response = await client.post(
+        "/api/v1/expenses/service/", json=expense_payload, headers=normal_user_token_headers
+    )
+    assert response.status_code == status.HTTP_201_CREATED, f"Failed: {response.text}"
+    data = response.json()
+    assert data["paid_by_user"]["id"] == test_user.id
+    assert len(data["participant_details"]) == 1
+    assert data["participant_details"][0]["user"]["id"] == test_user.id
+    assert data["participant_details"][0]["share_amount"] == 50.0
+
+@pytest.mark.asyncio
+async def test_create_expense_designate_other_user_as_payer_non_group(
+    client: AsyncClient,
+    normal_user_token_headers: dict[str, str], # User1 creates
+    test_user_2: User, # User2 will be designated payer
+    test_currency: Currency,
+):
+    expense_payload = {
+        "description": "Other Payer Non-Group",
+        "amount": 70.0,
+        "currency_id": test_currency.id,
+        "paid_by_user_id": test_user_2.id, # User1 designates User2 as payer
+        "split_method": "unequal",
+        # User2 (payer) will be sole participant
+    }
+    response = await client.post(
+        "/api/v1/expenses/service/", json=expense_payload, headers=normal_user_token_headers
+    )
+    assert response.status_code == status.HTTP_201_CREATED, f"Failed: {response.text}"
+    data = response.json()
+    assert data["paid_by_user"]["id"] == test_user_2.id
+    assert len(data["participant_details"]) == 1
+    assert data["participant_details"][0]["user"]["id"] == test_user_2.id
+    assert data["participant_details"][0]["share_amount"] == 70.0
+
+@pytest.mark.asyncio
+async def test_create_group_expense_creator_pays_other_member_participates(
+    client: AsyncClient,
+    normal_user_token_headers: dict[str, str], # test_user's token
+    test_user: User, # Creator and payer
+    test_user_2: User, # Participant
+    test_group_shared_with_user2: Group, # Group with test_user and test_user_2
+    test_currency: Currency,
+):
+    expense_payload = {
+        "description": "Group Expense, Creator Pays",
+        "amount": 100.0,
+        "currency_id": test_currency.id,
+        "group_id": test_group_shared_with_user2.id,
+        "paid_by_user_id": test_user.id, # Creator pays
+        "split_method": "equal",
+        "selected_participant_user_ids": [test_user.id, test_user_2.id],
+    }
+    response = await client.post(
+        "/api/v1/expenses/service/", json=expense_payload, headers=normal_user_token_headers
+    )
+    assert response.status_code == status.HTTP_201_CREATED, f"Failed: {response.text}"
+    data = response.json()
+    assert data["paid_by_user"]["id"] == test_user.id
+    assert data["group_id"] == test_group_shared_with_user2.id
+    assert len(data["participant_details"]) == 2
+
+@pytest.mark.asyncio
+async def test_create_group_expense_other_member_pays(
+    client: AsyncClient,
+    normal_user_token_headers: dict[str, str], # test_user's token (creator)
+    test_user: User, # Creator
+    test_user_2: User, # Designated payer and participant
+    test_group_shared_with_user2: Group,
+    test_currency: Currency,
+):
+    expense_payload = {
+        "description": "Group Expense, Other Member Pays",
+        "amount": 120.0,
+        "currency_id": test_currency.id,
+        "group_id": test_group_shared_with_user2.id,
+        "paid_by_user_id": test_user_2.id, # test_user_2 (member) pays
+        "split_method": "equal",
+        "selected_participant_user_ids": [test_user.id, test_user_2.id],
+    }
+    response = await client.post(
+        "/api/v1/expenses/service/", json=expense_payload, headers=normal_user_token_headers
+    )
+    assert response.status_code == status.HTTP_201_CREATED, f"Failed: {response.text}"
+    data = response.json()
+    assert data["paid_by_user"]["id"] == test_user_2.id
+    assert data["group_id"] == test_group_shared_with_user2.id
+    assert len(data["participant_details"]) == 2
+
+@pytest.mark.asyncio
+async def test_create_group_expense_fail_payer_not_in_group(
+    client: AsyncClient,
+    normal_user_token_headers: dict[str, str], # test_user's token (creator)
+    test_user: User, # Creator (member of test_group)
+    test_user_3_with_token: dict, # User not in the group
+    test_group: Group, # Group created by test_user, test_user_3 is NOT a member
+    test_currency: Currency,
+):
+    other_user_id = test_user_3_with_token["user"].id
+    expense_payload = {
+        "description": "Payer Not In Group Fail",
+        "amount": 100.0,
+        "currency_id": test_currency.id,
+        "group_id": test_group.id,
+        "paid_by_user_id": other_user_id, # This user is not in test_group
+        "split_method": "unequal",
+        "participant_shares": [{"user_id": test_user.id, "share_amount": 100.0}],
+    }
+    response = await client.post(
+        "/api/v1/expenses/service/", json=expense_payload, headers=normal_user_token_headers
+    )
+    assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+    assert "Designated payer is not a member of the group" in response.json()["detail"]
+
+@pytest.mark.asyncio
+async def test_create_group_expense_fail_creator_not_in_group(
+    client: AsyncClient,
+    test_user_3_with_token: dict, # Creator, but not part of target_group
+    test_group: Group, # Group created by test_user (normal_user)
+    test_currency: Currency,
+):
+    creator_headers = test_user_3_with_token["headers"]
+    creator_id = test_user_3_with_token["user"].id
+
+    expense_payload = {
+        "description": "Creator Not In Group Fail",
+        "amount": 100.0,
+        "currency_id": test_currency.id,
+        "group_id": test_group.id, # Target group test_user_3 is not a member of
+        "paid_by_user_id": creator_id,
+        "split_method": "unequal",
+        "participant_shares": [{"user_id": creator_id, "share_amount": 100.0}],
+    }
+    response = await client.post(
+        "/api/v1/expenses/service/", json=expense_payload, headers=creator_headers
+    )
+    assert response.status_code == status.HTTP_403_FORBIDDEN
+    assert "Creator must be a member of the group" in response.json()["detail"]
+
+@pytest.mark.asyncio
+async def test_create_group_expense_fail_participant_not_in_group(
+    client: AsyncClient,
+    normal_user_token_headers: dict[str, str], # test_user's token (creator)
+    test_user: User, # Creator (member of test_group)
+    test_user_3_with_token: dict, # User not in the group, attempted participant
+    test_group: Group, # Group created by test_user
+    test_currency: Currency,
+):
+    non_member_participant_id = test_user_3_with_token["user"].id
+    expense_payload = {
+        "description": "Participant Not In Group Fail",
+        "amount": 100.0,
+        "currency_id": test_currency.id,
+        "group_id": test_group.id,
+        "paid_by_user_id": test_user.id,
+        "split_method": "equal",
+        "selected_participant_user_ids": [test_user.id, non_member_participant_id],
+    }
+    response = await client.post(
+        "/api/v1/expenses/service/", json=expense_payload, headers=normal_user_token_headers
+    )
+    assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+    assert f"Participant user ID {non_member_participant_id} is not a member of the group" in response.json()["detail"]
+
+# VI. Tests for Split Methods
+# Equal Split
+@pytest.mark.asyncio
+async def test_create_expense_equal_split_success(
+    client: AsyncClient,
+    normal_user_token_headers: dict[str, str],
+    test_user: User,
+    test_user_2: User,
+    test_currency: Currency,
+):
+    amount = 101.0  # Amount that doesn't divide perfectly
+    participants = [test_user.id, test_user_2.id]
+    expense_payload = {
+        "description": "Equal Split Test",
+        "amount": amount,
+        "currency_id": test_currency.id,
+        "paid_by_user_id": test_user.id,
+        "split_method": "equal",
+        "selected_participant_user_ids": participants,
+    }
+    response = await client.post("/api/v1/expenses/service/", json=expense_payload, headers=normal_user_token_headers)
+    assert response.status_code == status.HTTP_201_CREATED, f"Failed: {response.text}"
+    data = response.json()
+    assert data["split_method"] == "equal"
+    assert sorted(data["selected_participant_user_ids"]) == sorted(participants)
+    assert len(data["participant_details"]) == 2
+
+    shares = [p["share_amount"] for p in data["participant_details"]]
+    assert sum(shares) == amount
+    # Check individual shares (50.50 each, one might have remainder)
+    assert 50.49 < shares[0] < 50.51 or 50.49 < shares[1] < 50.51 # Basic check for near equality
+    # More precise: one should be 50.50, other 50.50 due to rounding logic for 101.0 / 2
+    # With current remainder logic (add to first):
+    user1_share = next(p["share_amount"] for p in data["participant_details"] if p["user"]["id"] == participants[0])
+    user2_share = next(p["share_amount"] for p in data["participant_details"] if p["user"]["id"] == participants[1])
+
+    # For 101.0 / 2 = 50.5. individual_share = 50.50. remainder = 0.
+    # So both should be 50.50
+    assert user1_share == 50.50
+    assert user2_share == 50.50
+
+
+@pytest.mark.asyncio
+async def test_create_expense_equal_split_fail_no_participants_selected(
+    client: AsyncClient, normal_user_token_headers: dict[str, str], test_user: User, test_currency: Currency
+):
+    expense_payload = {
+        "description": "Equal Split No Participants",
+        "amount": 100.0,
+        "currency_id": test_currency.id,
+        "paid_by_user_id": test_user.id,
+        "split_method": "equal",
+        "selected_participant_user_ids": None, # Missing
+    }
+    response = await client.post("/api/v1/expenses/service/", json=expense_payload, headers=normal_user_token_headers)
+    assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+    assert "selected_participant_user_ids is required" in response.json()["detail"]
+
+    expense_payload["selected_participant_user_ids"] = [] # Empty list
+    response = await client.post("/api/v1/expenses/service/", json=expense_payload, headers=normal_user_token_headers)
+    assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+    assert "Participant list cannot be empty" in response.json()["detail"]
+
+# Percentage Split
+@pytest.mark.asyncio
+async def test_create_expense_percentage_split_success(
+    client: AsyncClient, normal_user_token_headers: dict[str, str], test_user: User, test_user_2: User, test_currency: Currency
+):
+    amount = 200.0
+    shares_percent = [
+        {"user_id": test_user.id, "share_amount": 60.0}, # 60%
+        {"user_id": test_user_2.id, "share_amount": 40.0}, # 40%
+    ]
+    expense_payload = {
+        "description": "Percentage Split Test",
+        "amount": amount,
+        "currency_id": test_currency.id,
+        "paid_by_user_id": test_user.id,
+        "split_method": "percentage",
+        "participant_shares": shares_percent,
+    }
+    response = await client.post("/api/v1/expenses/service/", json=expense_payload, headers=normal_user_token_headers)
+    assert response.status_code == status.HTTP_201_CREATED, f"Failed: {response.text}"
+    data = response.json()
+    assert data["split_method"] == "percentage"
+    assert data["selected_participant_user_ids"] is None
+
+    details_user1 = next((p for p in data["participant_details"] if p["user"]["id"] == test_user.id), None)
+    details_user2 = next((p for p in data["participant_details"] if p["user"]["id"] == test_user_2.id), None)
+
+    assert details_user1 is not None and details_user1["share_amount"] == 120.0 # 60% of 200
+    assert details_user2 is not None and details_user2["share_amount"] == 80.0  # 40% of 200
+
+@pytest.mark.asyncio
+async def test_create_expense_percentage_split_fail_sum_not_100(
+    client: AsyncClient, normal_user_token_headers: dict[str, str], test_user: User, test_user_2: User, test_currency: Currency
+):
+    expense_payload = {
+        "description": "Percentage Sum Fail",
+        "amount": 100.0,
+        "currency_id": test_currency.id,
+        "paid_by_user_id": test_user.id,
+        "split_method": "percentage",
+        "participant_shares": [
+            {"user_id": test_user.id, "share_amount": 50.0},
+            {"user_id": test_user_2.id, "share_amount": 40.0}, # Sums to 90%
+        ],
+    }
+    response = await client.post("/api/v1/expenses/service/", json=expense_payload, headers=normal_user_token_headers)
+    assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+    assert "Percentages must sum up to 100" in response.json()["detail"]
+
+@pytest.mark.asyncio
+async def test_create_expense_percentage_split_fail_invalid_percentage_value(
+    client: AsyncClient, normal_user_token_headers: dict[str, str], test_user: User, test_currency: Currency
+):
+    expense_payload = {
+        "description": "Invalid Percentage Value",
+        "amount": 100.0,
+        "currency_id": test_currency.id,
+        "paid_by_user_id": test_user.id,
+        "split_method": "percentage",
+        "participant_shares": [{"user_id": test_user.id, "share_amount": 110.0}], # > 100
+    }
+    response = await client.post("/api/v1/expenses/service/", json=expense_payload, headers=normal_user_token_headers)
+    assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+    assert "Invalid percentage" in response.json()["detail"]
+
+    expense_payload["participant_shares"] = [{"user_id": test_user.id, "share_amount": 0.0}] # Zero
+    response = await client.post("/api/v1/expenses/service/", json=expense_payload, headers=normal_user_token_headers)
+    assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+    assert "Invalid percentage" in response.json()["detail"]
+
+@pytest.mark.asyncio
+async def test_create_expense_percentage_split_fail_no_shares_provided(
+    client: AsyncClient, normal_user_token_headers: dict[str, str], test_user: User, test_currency: Currency
+):
+    expense_payload = {
+        "description": "Percentage No Shares",
+        "amount": 100.0,
+        "currency_id": test_currency.id,
+        "paid_by_user_id": test_user.id,
+        "split_method": "percentage",
+        "participant_shares": None, # Missing
+    }
+    response = await client.post("/api/v1/expenses/service/", json=expense_payload, headers=normal_user_token_headers)
+    assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+    assert "participant_shares is required for 'percentage' split" in response.json()["detail"]


### PR DESCRIPTION
This commit introduces several enhancements to expense management:

- Payer Selection: Allows specifying a payer different from the creator for an expense, with validation for group memberships.
- New Split Methods: Implements 'equal' and 'percentage' split methods in addition to the existing 'unequal' (custom) splits.
- Receipt Uploads: Adds functionality to upload receipt images for expenses, storing them locally and associating the URL with the expense.

Key changes include:
- Updates to `Expense` model and `ExpenseCreate`/`ExpenseRead` schemas to support these features (e.g., `paid_by_user_id`, `split_method`, `selected_participant_user_ids`, `receipt_image_url`).
- Modifications to expense creation endpoints in `routers/expenses.py` to handle the new logic and validations.
- A new endpoint `POST /expenses/{expense_id}/upload-receipt` for managing receipt image uploads.
- Configuration in `main.py` for serving uploaded static files.
- Comprehensive updates and additions to tests in `tests/test_expenses.py` and new file `tests/test_expense_receipts.py` to cover all new functionalities and ensure existing ones remain robust.