### PR TITLE
Implement balance calculation and display feature

### DIFF
--- a/app/src/services/balance_service.py
+++ b/app/src/services/balance_service.py
@@ -1,0 +1,368 @@
+from typing import Dict, List, Tuple
+from collections import defaultdict
+from sqlmodel.ext.asyncio.session import AsyncSession
+from sqlmodel import select, col
+from sqlalchemy.orm import selectinload
+
+from app.src.models.models import User, Group, Expense, ExpenseParticipant, Currency, Transaction # Added Transaction
+from app.src.models.schemas import (
+    DebtDetail,
+    CreditDetail,
+    UserGroupBalance,
+    GroupBalanceSummary,
+    GroupBalanceUserPerspective,
+    UserOverallBalance,
+    UserRead,
+)
+
+
+async def calculate_group_balances(
+    group_id: int, db_user_id: int, session: AsyncSession
+) -> GroupBalanceSummary:
+    """
+    Calculates who owes whom within a specific group.
+    Considers settled amounts and different currencies.
+    """
+    group_stmt = await session.exec(
+        select(Group)
+        .where(Group.id == group_id)
+        .options(
+            selectinload(Group.members),
+            selectinload(Group.expenses)
+            .selectinload(Expense.currency),  # Load currency for each expense
+            selectinload(Group.expenses)
+            .selectinload(Expense.paid_by), # Load payer for each expense
+            selectinload(Group.expenses)
+            .selectinload(Expense.all_participant_details)
+            .selectinload(ExpenseParticipant.user), # Load user for each participant
+            selectinload(Group.expenses)
+            .selectinload(Expense.all_participant_details)
+            .selectinload(ExpenseParticipant.transaction) # For settled amounts
+            .selectinload(Transaction.currency), # Currency of settlement transaction (if needed)
+        )
+    )
+    group = group_stmt.one_or_none()
+
+    if not group:
+        # Or raise HTTPException(status_code=404, detail="Group not found")
+        return GroupBalanceSummary(group_id=group_id, group_name="Not Found", members_balances=[])
+
+    # Check if the requesting user is a member of the group (optional, could be handled at router level)
+    # if not any(member.id == db_user_id for member in group.members):
+    #     # Or raise HTTPException(status_code=403, detail="User not member of group")
+    #     return GroupBalanceSummary(group_id=group_id, group_name=group.name, members_balances=[])
+
+
+    # Initialize balances for all members
+    # Balances: Dict[Tuple[user_id_debtor, user_id_creditor, currency_code], amount_owed]
+    # Positive amount means debtor owes creditor.
+    member_net_balances: Dict[Tuple[int, int, str], float] = defaultdict(float)
+
+    for expense in group.expenses:
+        if not expense.currency: # Should not happen if data is consistent
+            continue
+
+        expense_currency_code = expense.currency.code
+        payer_id = expense.paid_by_user_id
+
+        for participant_detail in expense.all_participant_details:
+            debtor_id = participant_detail.user_id
+
+            if debtor_id == payer_id:
+                continue # Payer does not owe themselves for their own payment
+
+            share_amount = participant_detail.share_amount
+
+            # Adjust for settled amounts
+            # This assumes settlement currency is the same as expense currency.
+            # If settlement can be in a different currency, conversion would be needed here.
+            # For now, we assume settled_amount_in_transaction_currency is comparable to share_amount.
+            if participant_detail.settled_amount_in_transaction_currency:
+                share_amount -= participant_detail.settled_amount_in_transaction_currency
+
+            if share_amount <= 0: # Fully settled or over-settled
+                continue
+
+            # Debtor owes Payer
+            member_net_balances[(debtor_id, payer_id, expense_currency_code)] += share_amount
+
+    # Simplify debts: If A owes B $10 and B owes A $5 (in same currency), then A owes B $5.
+    simplified_balances: Dict[Tuple[int, int, str], float] = defaultdict(float)
+    processed_pairs_currencies = set()
+
+    for (user_a_id, user_b_id, currency_code), amount_a_owes_b in member_net_balances.items():
+        if (user_a_id, user_b_id, currency_code) in processed_pairs_currencies or \
+           (user_b_id, user_a_id, currency_code) in processed_pairs_currencies:
+            continue
+
+        amount_b_owes_a = member_net_balances.get((user_b_id, user_a_id, currency_code), 0.0)
+
+        net_a_owes_b = amount_a_owes_b - amount_b_owes_a
+
+        if net_a_owes_b > 0:
+            simplified_balances[(user_a_id, user_b_id, currency_code)] = net_a_owes_b
+        elif net_a_owes_b < 0:
+            simplified_balances[(user_b_id, user_a_id, currency_code)] = -net_a_owes_b
+
+        processed_pairs_currencies.add((user_a_id, user_b_id, currency_code))
+        processed_pairs_currencies.add((user_b_id, user_a_id, currency_code))
+
+
+    # Construct the GroupBalanceSummary response
+    member_user_map = {member.id: member for member in group.members}
+    user_group_balances: List[UserGroupBalance] = []
+
+    for member_id, member_user_obj in member_user_map.items():
+        user_balance = UserGroupBalance(
+            user_id=member_id,
+            username=member_user_obj.username,
+            # owes_others_total, others_owe_user_total, net_balance_in_group will be calculated per currency later
+            # For now, initialize with empty dicts for by_currency fields
+            debts_to_specific_users_by_currency=defaultdict(list),
+            credits_from_specific_users_by_currency=defaultdict(list),
+        )
+
+        total_owes_for_member_by_currency = defaultdict(float)
+        total_owed_to_member_by_currency = defaultdict(float)
+
+        for (debtor_id, creditor_id, currency_code), amount in simplified_balances.items():
+            if debtor_id == member_id: # This member (member_id) owes creditor_id
+                creditor_user_obj = member_user_map.get(creditor_id)
+                if creditor_user_obj:
+                    debt_detail = DebtDetail(
+                        owes_user_id=creditor_id,
+                        owes_username=creditor_user_obj.username,
+                        amount=amount,
+                        currency_code=currency_code,
+                    )
+                    user_balance.debts_to_specific_users_by_currency[currency_code].append(debt_detail)
+                    total_owes_for_member_by_currency[currency_code] += amount
+
+            elif creditor_id == member_id: # This member (member_id) is owed by debtor_id
+                debtor_user_obj = member_user_map.get(debtor_id)
+                if debtor_user_obj:
+                    credit_detail = CreditDetail(
+                        owed_by_user_id=debtor_id,
+                        owed_by_username=debtor_user_obj.username,
+                        amount=amount,
+                        currency_code=currency_code,
+                    )
+                    user_balance.credits_from_specific_users_by_currency[currency_code].append(credit_detail)
+                    total_owed_to_member_by_currency[currency_code] += amount
+
+        # Calculate overall totals for this member (can be complex if multiple currencies)
+        # For simplicity, we'll leave the single float fields as 0 or sum them if only one currency.
+        # The by_currency fields provide the precise breakdown.
+        # If we need a single value for owes_others_total, it implies conversion to a common currency.
+        # For now, we'll sum them up if there's only one currency involved for this user, otherwise 0.
+
+        if len(total_owes_for_member_by_currency) == 1:
+            user_balance.owes_others_total = list(total_owes_for_member_by_currency.values())[0]
+        # else: sum across currencies if a primary currency is defined, or keep 0.
+
+        if len(total_owed_to_member_by_currency) == 1:
+            user_balance.others_owe_user_total = list(total_owed_to_member_by_currency.values())[0]
+        # else: sum across currencies or keep 0.
+
+        user_balance.net_balance_in_group = user_balance.others_owe_user_total - user_balance.owes_others_total
+
+        user_group_balances.append(user_balance)
+
+    return GroupBalanceSummary(
+        group_id=group.id,
+        group_name=group.name,
+        members_balances=user_group_balances,
+    )
+
+
+async def calculate_user_overall_balances(
+    user_id: int, session: AsyncSession
+) -> UserOverallBalance:
+    """
+    Calculates a user's net balance (total owed vs. total owing) across all their involvements.
+    """
+    user_stmt = await session.exec(
+        select(User)
+        .where(User.id == user_id)
+        .options(
+            selectinload(User.groups).selectinload(Group.members) # For group names and member details if needed later
+        )
+    )
+    user = user_stmt.one_or_none()
+
+    if not user:
+        # Or raise HTTPException(status_code=404, detail="User not found")
+        # Return an empty/default UserOverallBalance
+        return UserOverallBalance(user_id=user_id)
+
+    overall_balance = UserOverallBalance(
+        user_id=user_id,
+        # Initialize with defaultdicts for by_currency fields
+        total_you_owe_by_currency=defaultdict(float),
+        total_owed_to_you_by_currency=defaultdict(float),
+        net_overall_balance_by_currency=defaultdict(float),
+        breakdown_by_group=[],
+        detailed_debts_by_currency=defaultdict(list),
+        detailed_credits_by_currency=defaultdict(list),
+    )
+
+    for group_membership_link in user.groups: # user.groups here are actual Group objects due to relationship loading
+        group_summary = await calculate_group_balances(group_membership_link.id, user_id, session)
+
+        user_perspective_in_group = None
+
+        for member_balance in group_summary.members_balances:
+            if member_balance.user_id == user_id:
+                # Calculate net balance for this user in this group, per currency
+                net_in_group_by_currency = defaultdict(float)
+
+                for currency_code, credits in member_balance.credits_from_specific_users_by_currency.items():
+                    for credit in credits:
+                        net_in_group_by_currency[currency_code] += credit.amount
+                        # Aggregate to overall credits
+                        overall_balance.total_owed_to_you_by_currency[currency_code] += credit.amount
+                        # Add to detailed_credits_by_currency, ensuring no duplicates if user in multiple groups owes same person
+                        # This requires careful aggregation based on (owed_by_user_id, currency_code)
+
+                for currency_code, debts in member_balance.debts_to_specific_users_by_currency.items():
+                    for debt in debts:
+                        net_in_group_by_currency[currency_code] -= debt.amount
+                        # Aggregate to overall debts
+                        overall_balance.total_you_owe_by_currency[currency_code] += debt.amount
+                        # Add to detailed_debts_by_currency
+
+                # For GroupBalanceUserPerspective, we need one entry per currency for this group
+                for currency_code, net_amount in net_in_group_by_currency.items():
+                    overall_balance.breakdown_by_group.append(
+                        GroupBalanceUserPerspective(
+                            group_id=group_summary.group_id,
+                            group_name=group_summary.group_name,
+                            your_net_balance_in_group=net_amount,
+                            currency_code=currency_code,
+                        )
+                    )
+                break # Found the user's balance in this group
+
+    # Aggregate detailed debts and credits across all groups
+    # This is tricky because calculate_group_balances already gives simplified debts/credits within a group.
+    # We need to sum these up globally.
+    # For example, if User A owes User B $10 in Group 1 (USD) and $5 in Group 2 (USD),
+    # UserOverallBalance should show User A owes User B $15 (USD).
+
+    # Re-fetch all expenses involving the user to correctly aggregate global debts/credits
+    # This is a more direct way to get overall debts/credits rather than summing up group-level simplifications.
+
+    all_expenses_stmt = await session.exec(
+        select(Expense)
+        .join(ExpenseParticipant, Expense.id == ExpenseParticipant.expense_id)
+        .where((Expense.paid_by_user_id == user_id) | (ExpenseParticipant.user_id == user_id))
+        .options(
+            selectinload(Expense.currency),
+            selectinload(Expense.paid_by),
+            selectinload(Expense.all_participant_details).selectinload(ExpenseParticipant.user),
+            selectinload(Expense.all_participant_details).selectinload(ExpenseParticipant.transaction),
+        )
+        .distinct()
+    )
+    all_user_expenses = all_expenses_stmt.unique().all()
+
+    # Similar to group calculation, but global: Dict[Tuple[debtor, creditor, currency], amount]
+    global_net_balances: Dict[Tuple[int, int, str], float] = defaultdict(float)
+
+    for expense in all_user_expenses:
+        if not expense.currency:
+            continue
+        expense_currency_code = expense.currency.code
+        payer_id = expense.paid_by_user_id
+
+        for p_detail in expense.all_participant_details:
+            debtor_id = p_detail.user_id
+            if debtor_id == payer_id:
+                continue
+
+            share = p_detail.share_amount
+            if p_detail.settled_amount_in_transaction_currency:
+                # Assuming settlement currency matches expense currency for now
+                share -= p_detail.settled_amount_in_transaction_currency
+
+            if share <= 0:
+                continue
+
+            global_net_balances[(debtor_id, payer_id, expense_currency_code)] += share
+
+    # Simplify global balances
+    simplified_global_balances: Dict[Tuple[int, int, str], float] = defaultdict(float)
+    processed_global_pairs = set()
+
+    for (debtor_id, creditor_id, currency_code), amount_debtor_owes_creditor in global_net_balances.items():
+        pair_key = tuple(sorted((debtor_id, creditor_id))) + (currency_code,)
+        if pair_key in processed_global_pairs:
+            continue
+
+        amount_creditor_owes_debtor = global_net_balances.get((creditor_id, debtor_id, currency_code), 0.0)
+
+        net_debtor_owes_creditor = amount_debtor_owes_creditor - amount_creditor_owes_debtor
+
+        if net_debtor_owes_creditor > 0:
+            simplified_global_balances[(debtor_id, creditor_id, currency_code)] = net_debtor_owes_creditor
+        elif net_debtor_owes_creditor < 0:
+            simplified_global_balances[(creditor_id, debtor_id, currency_code)] = -net_debtor_owes_creditor
+
+        processed_global_pairs.add(pair_key)
+
+    # Populate UserOverallBalance.detailed_debts_by_currency and detailed_credits_by_currency
+    # And also recalculate total_you_owe_by_currency, total_owed_to_you_by_currency
+
+    overall_balance.total_you_owe_by_currency.clear()
+    overall_balance.total_owed_to_you_by_currency.clear()
+    overall_balance.detailed_debts_by_currency.clear()
+    overall_balance.detailed_credits_by_currency.clear()
+
+    # Temporary map to fetch user objects for usernames efficiently
+    involved_user_ids = set()
+    for debtor_id, creditor_id, _ in simplified_global_balances.keys():
+        involved_user_ids.add(debtor_id)
+        involved_user_ids.add(creditor_id)
+
+    if involved_user_ids:
+        users_stmt = await session.exec(select(User).where(col(User.id).in_(list(involved_user_ids))))
+        involved_users_map = {u.id: u for u in users_stmt.all()}
+    else:
+        involved_users_map = {}
+
+
+    for (debtor_id, creditor_id, currency_code), amount in simplified_global_balances.items():
+        if debtor_id == user_id: # Current user (user_id) owes creditor_id
+            creditor_obj = involved_users_map.get(creditor_id)
+            if creditor_obj:
+                debt_detail = DebtDetail(
+                    owes_user_id=creditor_id,
+                    owes_username=creditor_obj.username,
+                    amount=amount,
+                    currency_code=currency_code
+                )
+                overall_balance.detailed_debts_by_currency[currency_code].append(debt_detail)
+                overall_balance.total_you_owe_by_currency[currency_code] += amount
+
+        elif creditor_id == user_id: # Current user (user_id) is owed by debtor_id
+            debtor_obj = involved_users_map.get(debtor_id)
+            if debtor_obj:
+                credit_detail = CreditDetail(
+                    owed_by_user_id=debtor_id,
+                    owed_by_username=debtor_obj.username,
+                    amount=amount,
+                    currency_code=currency_code
+                )
+                overall_balance.detailed_credits_by_currency[currency_code].append(credit_detail)
+                overall_balance.total_owed_to_you_by_currency[currency_code] += amount
+
+    # Calculate net_overall_balance_by_currency
+    all_involved_currencies = set(overall_balance.total_you_owe_by_currency.keys()) | \
+                              set(overall_balance.total_owed_to_you_by_currency.keys())
+
+    for currency_code in all_involved_currencies:
+        owed = overall_balance.total_owed_to_you_by_currency.get(currency_code, 0.0)
+        owes = overall_balance.total_you_owe_by_currency.get(currency_code, 0.0)
+        overall_balance.net_overall_balance_by_currency[currency_code] = owed - owes
+
+    return overall_balance

--- a/app/tests/test_balance_service.py
+++ b/app/tests/test_balance_service.py
@@ -1,0 +1,553 @@
+import pytest
+from typing import List, Optional, Any, Dict
+from collections import defaultdict
+from sqlmodel.ext.asyncio.session import AsyncSession
+from sqlalchemy.ext.asyncio import create_async_engine
+from sqlmodel import SQLModel, Field, create_engine
+
+
+from app.src.models.models import User, Group, Expense, Currency, ExpenseParticipant, UserGroupLink, Transaction
+from app.src.models.schemas import (
+    GroupBalanceSummary,
+    UserOverallBalance,
+    UserGroupBalance,
+    DebtDetail,
+    CreditDetail
+)
+from app.src.services import balance_service
+from app.src.db.database import get_session # For potential direct session usage if needed
+
+# Using engine and session fixtures from conftest.py
+
+# Helper functions to create test data
+# These will use the session provided by the 'async_db_session' fixture from conftest.py
+async def create_user(async_db_session: AsyncSession, username: str, email: str, id: Optional[int] = None) -> User:
+    user = User(id=id, username=username, email=email, hashed_password="hashedpassword", email_verified=True)
+    db_session.add(user)
+    await db_session.commit()
+    await async_db_session.refresh(user)
+    return user
+
+async def create_currency(async_db_session: AsyncSession, code: str, name: str, id: Optional[int] = None) -> Currency:
+    currency = Currency(id=id, code=code, name=name)
+    async_db_session.add(currency)
+    await async_db_session.commit()
+    await async_db_session.refresh(currency)
+    return currency
+
+async def create_group(async_db_session: AsyncSession, name: str, created_by_user_id: int, id: Optional[int] = None) -> Group:
+    group = Group(id=id, name=name, created_by_user_id=created_by_user_id)
+    async_db_session.add(group)
+    await async_db_session.commit()
+    await async_db_session.refresh(group)
+    return group
+
+async def add_user_to_group(async_db_session: AsyncSession, user_id: int, group_id: int):
+    link = UserGroupLink(user_id=user_id, group_id=group_id)
+    async_db_session.add(link)
+    await async_db_session.commit()
+
+async def create_expense(
+    async_db_session: AsyncSession,
+    description: str,
+    amount: float,
+    currency_id: int,
+    paid_by_user_id: int,
+    group_id: Optional[int] = None,
+    id: Optional[int] = None,
+    participants_data: Optional[List[Dict[str, Any]]] = None # [{"user_id": int, "share_amount": float, "settled_amount": float (optional)}]
+) -> Expense:
+    expense = Expense(
+        id=id,
+        description=description,
+        amount=amount,
+        currency_id=currency_id,
+        paid_by_user_id=paid_by_user_id,
+        group_id=group_id,
+    )
+    async_db_session.add(expense)
+    await async_db_session.commit()
+    await async_db_session.refresh(expense)
+
+    if participants_data:
+        for p_data in participants_data:
+            participant = ExpenseParticipant(
+                expense_id=expense.id,
+                user_id=p_data["user_id"],
+                share_amount=p_data["share_amount"],
+                settled_amount_in_transaction_currency=p_data.get("settled_amount")
+            )
+            # If settled_amount is provided, we might need a dummy transaction
+            # For simplicity in these unit tests, we'll assume settled_transaction_id can be null
+            # or that the balance service correctly handles it even if the transaction object isn't fully loaded/created here.
+            async_db_session.add(participant)
+        await async_db_session.commit()
+        await async_db_session.refresh(expense, attribute_names=['all_participant_details'])
+    return expense
+
+@pytest.mark.asyncio
+async def test_calculate_group_balances_no_expenses(async_db_session: AsyncSession):
+    user1 = await create_user(async_db_session, "user1", "user1@test.com", id=1)
+    group1 = await create_group(async_db_session, "Group1", user1.id, id=1)
+    await add_user_to_group(async_db_session, user1.id, group1.id)
+
+    summary = await balance_service.calculate_group_balances(group1.id, user1.id, async_db_session)
+
+    assert summary.group_id == group1.id
+    assert summary.group_name == group1.name
+    assert len(summary.members_balances) == 1
+    member_balance = summary.members_balances[0]
+    assert member_balance.user_id == user1.id
+    assert member_balance.owes_others_total == 0.0
+    assert member_balance.others_owe_user_total == 0.0
+    assert member_balance.net_balance_in_group == 0.0
+    assert not member_balance.debts_to_specific_users_by_currency
+    assert not member_balance.credits_from_specific_users_by_currency
+
+@pytest.mark.asyncio
+async def test_calculate_group_balances_single_expense_two_users(async_db_session: AsyncSession):
+    user1 = await create_user(async_db_session, "user1", "user1@test.com", id=1)
+    user2 = await create_user(async_db_session, "user2", "user2@test.com", id=2)
+    currency_usd = await create_currency(async_db_session, "USD", "US Dollar", id=1)
+    group1 = await create_group(async_db_session, "Group1", user1.id, id=1)
+    await add_user_to_group(async_db_session, user1.id, group1.id)
+    await add_user_to_group(async_db_session, user2.id, group1.id)
+
+    await create_expense(
+        async_db_session,
+        description="Lunch",
+        amount=100.0,
+        currency_id=currency_usd.id,
+        paid_by_user_id=user1.id,
+        group_id=group1.id,
+        participants_data=[
+            {"user_id": user1.id, "share_amount": 50.0},
+            {"user_id": user2.id, "share_amount": 50.0},
+        ],
+    )
+
+    summary = await balance_service.calculate_group_balances(group1.id, user1.id, async_db_session)
+    assert len(summary.members_balances) == 2
+
+    user1_balance = next(mb for mb in summary.members_balances if mb.user_id == user1.id)
+    user2_balance = next(mb for mb in summary.members_balances if mb.user_id == user2.id)
+
+    # User1 paid 100, their share is 50. So, User2 owes User1 50.
+    assert user1_balance.others_owe_user_total == 50.0
+    assert user1_balance.owes_others_total == 0.0
+    assert user1_balance.net_balance_in_group == 50.0
+    assert len(user1_balance.credits_from_specific_users_by_currency["USD"]) == 1
+    credit_detail_u1 = user1_balance.credits_from_specific_users_by_currency["USD"][0]
+    assert credit_detail_u1.owed_by_user_id == user2.id
+    assert credit_detail_u1.amount == 50.0
+
+    assert user2_balance.owes_others_total == 50.0
+    assert user2_balance.others_owe_user_total == 0.0
+    assert user2_balance.net_balance_in_group == -50.0
+    assert len(user2_balance.debts_to_specific_users_by_currency["USD"]) == 1
+    debt_detail_u2 = user2_balance.debts_to_specific_users_by_currency["USD"][0]
+    assert debt_detail_u2.owes_user_id == user1.id
+    assert debt_detail_u2.amount == 50.0
+
+@pytest.mark.asyncio
+async def test_calculate_group_balances_multiple_expenses_settlement(async_db_session: AsyncSession):
+    user1 = await create_user(async_db_session, "user1", "u1@test.com", id=1)
+    user2 = await create_user(async_db_session, "user2", "u2@test.com", id=2)
+    user3 = await create_user(async_db_session, "user3", "u3@test.com", id=3)
+    usd = await create_currency(async_db_session, "USD", "US Dollar", id=1)
+    group1 = await create_group(async_db_session, "G1", user1.id, id=1)
+    await add_user_to_group(async_db_session, user1.id, group1.id)
+    await add_user_to_group(async_db_session, user2.id, group1.id)
+    await add_user_to_group(async_db_session, user3.id, group1.id)
+
+    # Exp1: User1 paid 90 for U1,U2,U3 (30 each). U2 owes U1 30, U3 owes U1 30.
+    await create_expense(async_db_session, "Dinner", 90.0, usd.id, user1.id, group1.id, participants_data=[
+        {"user_id": user1.id, "share_amount": 30.0},
+        {"user_id": user2.id, "share_amount": 30.0},
+        {"user_id": user3.id, "share_amount": 30.0},
+    ])
+    # Exp2: User2 paid 60 for U1,U2 (30 each). U1 owes U2 30.
+    await create_expense(async_db_session, "Movies", 60.0, usd.id, user2.id, group1.id, participants_data=[
+        {"user_id": user1.id, "share_amount": 30.0},
+        {"user_id": user2.id, "share_amount": 30.0},
+    ])
+    # Exp3: User3 paid 30 for U1, U3 (15 each). U1 owes U3 15. U3's share of Exp1 (30) is partially settled by 10.
+    await create_expense(async_db_session, "Coffee", 30.0, usd.id, user3.id, group1.id, participants_data=[
+        {"user_id": user1.id, "share_amount": 15.0},
+        {"user_id": user3.id, "share_amount": 15.0, "settled_amount": 10.0}, # U3's share was 15, but let's assume this is a settlement for Exp1
+    ])
+    # To make the settlement test clearer, let's say user3's participation in Exp1 was settled by 10
+    # We need to update that specific ExpenseParticipant record. This is a bit tricky with current helpers.
+    # For now, the `settled_amount` in `create_expense` will apply to *that* expense's participant record.
+    # Let's adjust Exp1's participant data for U3 for settlement.
+    # This requires fetching and updating, or more complex setup.
+    # Simpler: assume Exp1 U3 share was 30, and U3 paid 10 towards it separately.
+    # The current model has settled_amount on ExpenseParticipant.
+    # Let's simulate U3's share in Exp1 being partially settled.
+    # This test will rely on the simplification logic.
+
+    # Initial state from expenses:
+    # U1: paid 90 (share 30), owed 30 by U2 (Exp1), owed 30 by U3 (Exp1). Net +60 for Exp1.
+    #     owes 30 to U2 (Exp2), owes 15 to U3 (Exp3). Net -45 for Exp2 & Exp3.
+    #     Overall U1: +60 - 45 = +15.
+    # U2: paid 60 (share 30), owed 30 by U1 (Exp2). Net +30 for Exp2.
+    #     owes 30 to U1 (Exp1). Net -30 for Exp1.
+    #     Overall U2: 0.
+    # U3: paid 30 (share 15), owed 15 by U1 (Exp3). Net +15 for Exp3.
+    #     owes 30 to U1 (Exp1). Net -30 for Exp1. (Assume the 10 settlement on Exp3 participant doesn't affect this for now)
+    #     Overall U3: +15 - 30 = -15.
+
+    # Simplified:
+    # U1 vs U2: U1 owes U2 (30(Exp2) - 30(Exp1)) = 0. No net between U1 and U2.
+    # U1 vs U3: U1 owes U3 (15(Exp3) - 30(Exp1)) = -15. So U3 owes U1 15.
+    # U2 vs U3: No direct transactions.
+
+    # So, U3 owes U1 15.
+    # U1: +15 (from U3)
+    # U2: 0
+    # U3: -15 (to U1)
+
+    summary = await balance_service.calculate_group_balances(group1.id, user1.id, async_db_session)
+
+    u1_b = next(mb for mb in summary.members_balances if mb.user_id == user1.id)
+    u2_b = next(mb for mb in summary.members_balances if mb.user_id == user2.id)
+    u3_b = next(mb for mb in summary.members_balances if mb.user_id == user3.id)
+
+    # Check U1
+    assert u1_b.net_balance_in_group == 15.0
+    assert u1_b.others_owe_user_total == 15.0 # From U3
+    assert u1_b.owes_others_total == 0.0
+    assert len(u1_b.credits_from_specific_users_by_currency.get("USD", [])) == 1
+    if u1_b.credits_from_specific_users_by_currency.get("USD"):
+      assert u1_b.credits_from_specific_users_by_currency["USD"][0].owed_by_user_id == user3.id
+      assert u1_b.credits_from_specific_users_by_currency["USD"][0].amount == 15.0
+
+    # Check U2
+    assert u2_b.net_balance_in_group == 0.0
+    assert not u2_b.credits_from_specific_users_by_currency.get("USD")
+    assert not u2_b.debts_to_specific_users_by_currency.get("USD")
+
+    # Check U3
+    assert u3_b.net_balance_in_group == -15.0
+    assert u3_b.owes_others_total == 15.0 # To U1
+    assert u3_b.others_owe_user_total == 0.0
+    assert len(u3_b.debts_to_specific_users_by_currency.get("USD", [])) == 1
+    if u3_b.debts_to_specific_users_by_currency.get("USD"):
+      assert u3_b.debts_to_specific_users_by_currency["USD"][0].owes_user_id == user1.id
+      assert u3_b.debts_to_specific_users_by_currency["USD"][0].amount == 15.0
+
+@pytest.mark.asyncio
+async def test_calculate_group_balances_multi_currency(async_db_session: AsyncSession):
+    user1 = await create_user(async_db_session, "user1", "u1@test.com", id=1)
+    user2 = await create_user(async_db_session, "user2", "u2@test.com", id=2)
+    usd = await create_currency(async_db_session, "USD", "US Dollar", id=1)
+    eur = await create_currency(async_db_session, "EUR", "Euro", id=2)
+    group1 = await create_group(async_db_session, "G1", user1.id, id=1)
+    await add_user_to_group(async_db_session, user1.id, group1.id)
+    await add_user_to_group(async_db_session, user2.id, group1.id)
+
+    # Exp1 (USD): U1 paid 100 for U1,U2 (50 each). U2 owes U1 50 USD.
+    await create_expense(async_db_session, "Lunch USD", 100.0, usd.id, user1.id, group1.id, participants_data=[
+        {"user_id": user1.id, "share_amount": 50.0}, {"user_id": user2.id, "share_amount": 50.0}
+    ])
+    # Exp2 (EUR): U2 paid 80 for U1,U2 (40 each). U1 owes U2 40 EUR.
+    await create_expense(async_db_session, "Taxi EUR", 80.0, eur.id, user2.id, group1.id, participants_data=[
+        {"user_id": user1.id, "share_amount": 40.0}, {"user_id": user2.id, "share_amount": 40.0}
+    ])
+
+    summary = await balance_service.calculate_group_balances(group1.id, user1.id, async_db_session)
+    u1_b = next(mb for mb in summary.members_balances if mb.user_id == user1.id)
+    u2_b = next(mb for mb in summary.members_balances if mb.user_id == user2.id)
+
+    # User1: owes 40 EUR to U2, is owed 50 USD by U2.
+    # Net balance field is tricky here. The by_currency fields are key.
+    # For owes_others_total and others_owe_user_total, if only one currency, it's that sum.
+    # Here, U1 owes in EUR, is owed in USD.
+    assert u1_b.owes_others_total == 40.0 # Assuming it picks one if mixed, or based on how feature doc wants summary fields.
+                                        # The detailed list is what matters more.
+    assert u1_b.others_owe_user_total == 50.0
+    # u1_b.net_balance_in_group will be 50 - 40 = 10 if we sum scalar fields.
+    # However, this is not currency-aware. Let's check detailed breakdowns.
+
+    assert len(u1_b.debts_to_specific_users_by_currency["EUR"]) == 1
+    assert u1_b.debts_to_specific_users_by_currency["EUR"][0].owes_user_id == user2.id
+    assert u1_b.debts_to_specific_users_by_currency["EUR"][0].amount == 40.0
+    assert u1_b.debts_to_specific_users_by_currency["EUR"][0].currency_code == "EUR"
+
+    assert len(u1_b.credits_from_specific_users_by_currency["USD"]) == 1
+    assert u1_b.credits_from_specific_users_by_currency["USD"][0].owed_by_user_id == user2.id
+    assert u1_b.credits_from_specific_users_by_currency["USD"][0].amount == 50.0
+    assert u1_b.credits_from_specific_users_by_currency["USD"][0].currency_code == "USD"
+
+
+    # User2: owes 50 USD to U1, is owed 40 EUR by U1.
+    assert u2_b.owes_others_total == 50.0
+    assert u2_b.others_owe_user_total == 40.0
+
+    assert len(u2_b.debts_to_specific_users_by_currency["USD"]) == 1
+    assert u2_b.debts_to_specific_users_by_currency["USD"][0].owes_user_id == user1.id
+    assert u2_b.debts_to_specific_users_by_currency["USD"][0].amount == 50.0
+    assert u2_b.debts_to_specific_users_by_currency["USD"][0].currency_code == "USD"
+
+    assert len(u2_b.credits_from_specific_users_by_currency["EUR"]) == 1
+    assert u2_b.credits_from_specific_users_by_currency["EUR"][0].owed_by_user_id == user1.id
+    assert u2_b.credits_from_specific_users_by_currency["EUR"][0].amount == 40.0
+    assert u2_b.credits_from_specific_users_by_currency["EUR"][0].currency_code == "EUR"
+
+
+@pytest.mark.asyncio
+async def test_calculate_user_overall_balances_no_groups_no_expenses(async_db_session: AsyncSession):
+    user1 = await create_user(async_db_session, "user1", "u1@test.com", id=1)
+
+    overall_summary = await balance_service.calculate_user_overall_balances(user1.id, async_db_session)
+
+    assert overall_summary.user_id == user1.id
+    assert not overall_summary.total_you_owe_by_currency
+    assert not overall_summary.total_owed_to_you_by_currency
+    assert not overall_summary.net_overall_balance_by_currency
+    assert not overall_summary.breakdown_by_group
+    assert not overall_summary.detailed_debts_by_currency
+    assert not overall_summary.detailed_credits_by_currency
+
+@pytest.mark.asyncio
+async def test_calculate_user_overall_balances_one_group(async_db_session: AsyncSession):
+    user1 = await create_user(async_db_session, "user1", "u1@test.com", id=1)
+    user2 = await create_user(async_db_session, "user2", "u2@test.com", id=2)
+    usd = await create_currency(async_db_session, "USD", "US Dollar", id=1)
+    group1 = await create_group(async_db_session, "G1", user1.id, id=1)
+    await add_user_to_group(async_db_session, user1.id, group1.id)
+    await add_user_to_group(async_db_session, user2.id, group1.id)
+
+    # U1 paid 100 for U1,U2 (50 each). U2 owes U1 50 USD.
+    await create_expense(async_db_session, "Lunch", 100.0, usd.id, user1.id, group1.id, participants_data=[
+        {"user_id": user1.id, "share_amount": 50.0}, {"user_id": user2.id, "share_amount": 50.0}
+    ])
+
+    overall_summary_u1 = await balance_service.calculate_user_overall_balances(user1.id, async_db_session)
+
+    assert overall_summary_u1.total_owed_to_you_by_currency["USD"] == 50.0
+    assert not overall_summary_u1.total_you_owe_by_currency.get("USD", 0.0) # Check it's 0 or not present
+    assert overall_summary_u1.net_overall_balance_by_currency["USD"] == 50.0
+
+    assert len(overall_summary_u1.breakdown_by_group) == 1
+    group_perspective = overall_summary_u1.breakdown_by_group[0]
+    assert group_perspective.group_id == group1.id
+    assert group_perspective.your_net_balance_in_group == 50.0
+    assert group_perspective.currency_code == "USD"
+
+    assert len(overall_summary_u1.detailed_credits_by_currency["USD"]) == 1
+    credit = overall_summary_u1.detailed_credits_by_currency["USD"][0]
+    assert credit.owed_by_user_id == user2.id
+    assert credit.amount == 50.0
+    assert not overall_summary_u1.detailed_debts_by_currency.get("USD")
+
+    overall_summary_u2 = await balance_service.calculate_user_overall_balances(user2.id, async_db_session)
+    assert overall_summary_u2.total_you_owe_by_currency["USD"] == 50.0
+    assert not overall_summary_u2.total_owed_to_you_by_currency.get("USD", 0.0)
+    assert overall_summary_u2.net_overall_balance_by_currency["USD"] == -50.0
+    assert len(overall_summary_u2.detailed_debts_by_currency["USD"]) == 1
+    debt = overall_summary_u2.detailed_debts_by_currency["USD"][0]
+    assert debt.owes_user_id == user1.id
+    assert debt.amount == 50.0
+
+@pytest.mark.asyncio
+async def test_calculate_user_overall_balances_multiple_groups_currencies_complex(async_db_session: AsyncSession):
+    u1 = await create_user(async_db_session, "u1", "u1@t.com", id=1)
+    u2 = await create_user(async_db_session, "u2", "u2@t.com", id=2)
+    u3 = await create_user(async_db_session, "u3", "u3@t.com", id=3)
+    usd = await create_currency(async_db_session, "USD", "USD", id=1)
+    eur = await create_currency(async_db_session, "EUR", "EUR", id=2)
+
+    g1 = await create_group(async_db_session, "G1", u1.id, id=1) # u1, u2
+    await add_user_to_group(async_db_session, u1.id, g1.id)
+    await add_user_to_group(async_db_session, u2.id, g1.id)
+
+    g2 = await create_group(async_db_session, "G2", u1.id, id=2) # u1, u3
+    await add_user_to_group(async_db_session, u1.id, g2.id)
+    await add_user_to_group(async_db_session, u3.id, g2.id)
+
+    # G1: u1 paid 100 USD for u1,u2 (50 each). u2 owes u1 50 USD.
+    await create_expense(async_db_session, "Lunch G1", 100.0, usd.id, u1.id, g1.id, participants_data=[
+        {"user_id": u1.id, "share_amount": 50.0}, {"user_id": u2.id, "share_amount": 50.0}])
+    # G1: u2 paid 80 EUR for u1,u2 (40 each). u1 owes u2 40 EUR.
+    await create_expense(async_db_session, "Taxi G1", 80.0, eur.id, u2.id, g1.id, participants_data=[
+        {"user_id": u1.id, "share_amount": 40.0}, {"user_id": u2.id, "share_amount": 40.0}])
+
+    # G2: u1 paid 60 USD for u1,u3 (30 each). u3 owes u1 30 USD.
+    await create_expense(async_db_session, "Coffee G2", 60.0, usd.id, u1.id, g2.id, participants_data=[
+        {"user_id": u1.id, "share_amount": 30.0}, {"user_id": u3.id, "share_amount": 30.0}])
+    # G2: u3 paid 20 EUR for u1,u3 (10 each). u1 owes u3 10 EUR.
+    await create_expense(async_db_session, "Snacks G2", 20.0, eur.id, u3.id, g2.id, participants_data=[
+        {"user_id": u1.id, "share_amount": 10.0}, {"user_id": u3.id, "share_amount": 10.0}])
+
+    # User1 Overall:
+    # Owed: 50 USD (by u2 from G1), 30 USD (by u3 from G2) => Total 80 USD owed to u1
+    # Owes: 40 EUR (to u2 from G1), 10 EUR (to u3 from G2) => Total 50 EUR u1 owes
+
+    summary_u1 = await balance_service.calculate_user_overall_balances(u1.id, async_db_session)
+
+    assert summary_u1.total_owed_to_you_by_currency["USD"] == 80.0
+    assert summary_u1.total_you_owe_by_currency["EUR"] == 50.0
+    assert not summary_u1.total_you_owe_by_currency.get("USD", 0.0)
+    assert not summary_u1.total_owed_to_you_by_currency.get("EUR", 0.0)
+
+    assert summary_u1.net_overall_balance_by_currency["USD"] == 80.0
+    assert summary_u1.net_overall_balance_by_currency["EUR"] == -50.0
+
+    # Detailed debts for U1 (owes u2 40 EUR, owes u3 10 EUR)
+    assert len(summary_u1.detailed_debts_by_currency["EUR"]) == 2
+    u1_debt_to_u2 = next(d for d in summary_u1.detailed_debts_by_currency["EUR"] if d.owes_user_id == u2.id)
+    u1_debt_to_u3 = next(d for d in summary_u1.detailed_debts_by_currency["EUR"] if d.owes_user_id == u3.id)
+    assert u1_debt_to_u2.amount == 40.0
+    assert u1_debt_to_u3.amount == 10.0
+
+    # Detailed credits for U1 (owed by u2 50 USD, owed by u3 30 USD)
+    assert len(summary_u1.detailed_credits_by_currency["USD"]) == 2
+    u1_credit_from_u2 = next(c for c in summary_u1.detailed_credits_by_currency["USD"] if c.owed_by_user_id == u2.id)
+    u1_credit_from_u3 = next(c for c in summary_u1.detailed_credits_by_currency["USD"] if c.owed_by_user_id == u3.id)
+    assert u1_credit_from_u2.amount == 50.0
+    assert u1_credit_from_u3.amount == 30.0
+
+    # Breakdown by group for U1
+    assert len(summary_u1.breakdown_by_group) == 4 # G1-USD, G1-EUR, G2-USD, G2-EUR
+
+    g1_usd_perspective = next(b for b in summary_u1.breakdown_by_group if b.group_id == g1.id and b.currency_code == "USD")
+    assert g1_usd_perspective.your_net_balance_in_group == 50.0 # Owed 50 USD by U2
+
+    g1_eur_perspective = next(b for b in summary_u1.breakdown_by_group if b.group_id == g1.id and b.currency_code == "EUR")
+    assert g1_eur_perspective.your_net_balance_in_group == -40.0 # Owes 40 EUR to U2
+
+    g2_usd_perspective = next(b for b in summary_u1.breakdown_by_group if b.group_id == g2.id and b.currency_code == "USD")
+    assert g2_usd_perspective.your_net_balance_in_group == 30.0 # Owed 30 USD by U3
+
+    g2_eur_perspective = next(b for b in summary_u1.breakdown_by_group if b.group_id == g2.id and b.currency_code == "EUR")
+    assert g2_eur_perspective.your_net_balance_in_group == -10.0 # Owes 10 EUR to U3
+
+
+@pytest.mark.asyncio
+async def test_calculate_group_balances_settled_expense(async_db_session: AsyncSession):
+    user1 = await create_user(async_db_session, "user1", "user1@test.com", id=1)
+    user2 = await create_user(async_db_session, "user2", "user2@test.com", id=2)
+    currency_usd = await create_currency(async_db_session, "USD", "US Dollar", id=1)
+    group1 = await create_group(async_db_session, "Group1", user1.id, id=1)
+    await add_user_to_group(async_db_session, user1.id, group1.id)
+    await add_user_to_group(async_db_session, user2.id, group1.id)
+
+    # User1 paid 100 for User1 (50) and User2 (50). User2's share is 50.
+    # User2's participation is partially settled by 20.
+    await create_expense(
+        async_db_session,
+        description="Concert Tickets",
+        amount=100.0,
+        currency_id=currency_usd.id,
+        paid_by_user_id=user1.id,
+        group_id=group1.id,
+        participants_data=[
+            {"user_id": user1.id, "share_amount": 50.0},
+            {"user_id": user2.id, "share_amount": 50.0, "settled_amount": 20.0},
+        ],
+    )
+
+    summary = await balance_service.calculate_group_balances(group1.id, user1.id, async_db_session)
+    user1_balance = next(mb for mb in summary.members_balances if mb.user_id == user1.id)
+    user2_balance = next(mb for mb in summary.members_balances if mb.user_id == user2.id)
+
+    # User2 originally owed 50, but 20 is settled. So, User2 owes User1 30.
+    assert user1_balance.others_owe_user_total == 30.0
+    assert user1_balance.credits_from_specific_users_by_currency["USD"][0].amount == 30.0
+
+    assert user2_balance.owes_others_total == 30.0
+    assert user2_balance.debts_to_specific_users_by_currency["USD"][0].amount == 30.0
+
+@pytest.mark.asyncio
+async def test_calculate_group_balances_fully_settled_expense_participant(async_db_session: AsyncSession):
+    user1 = await create_user(async_db_session, "user1", "user1@test.com", id=1)
+    user2 = await create_user(async_db_session, "user2", "user2@test.com", id=2)
+    currency_usd = await create_currency(async_db_session, "USD", "US Dollar", id=1)
+    group1 = await create_group(async_db_session, "Group1", user1.id, id=1)
+    await add_user_to_group(async_db_session, user1.id, group1.id)
+    await add_user_to_group(async_db_session, user2.id, group1.id)
+
+    await create_expense(
+        async_db_session,
+        description="Event",
+        amount=100.0,
+        currency_id=currency_usd.id,
+        paid_by_user_id=user1.id,
+        group_id=group1.id,
+        participants_data=[
+            {"user_id": user1.id, "share_amount": 50.0},
+            {"user_id": user2.id, "share_amount": 50.0, "settled_amount": 50.0}, # Fully settled
+        ],
+    )
+    summary = await balance_service.calculate_group_balances(group1.id, user1.id, async_db_session)
+    user1_balance = next(mb for mb in summary.members_balances if mb.user_id == user1.id)
+    user2_balance = next(mb for mb in summary.members_balances if mb.user_id == user2.id)
+
+    assert user1_balance.others_owe_user_total == 0.0
+    assert not user1_balance.credits_from_specific_users_by_currency.get("USD")
+
+    assert user2_balance.owes_others_total == 0.0
+    assert not user2_balance.debts_to_specific_users_by_currency.get("USD")
+
+# TODO: Add more tests for calculate_user_overall_balances, especially with settlements affecting overall picture.
+# For instance, a debt in one group might be offset by a credit in another, and how settlements affect this.
+# The current overall balance calculation re-evaluates debts globally, which should correctly handle this.
+# A test ensuring settlements are factored into the global calculation would be good.
+
+@pytest.mark.asyncio
+async def test_user_overall_balances_with_settlement_affecting_global(async_db_session: AsyncSession):
+    u1 = await create_user(async_db_session, "u1", "u1@t.com", id=1)
+    u2 = await create_user(async_db_session, "u2", "u2@t.com", id=2)
+    usd = await create_currency(async_db_session, "USD", "USD", id=1)
+
+    g1 = await create_group(async_db_session, "G1", u1.id, id=1)
+    await add_user_to_group(async_db_session, u1.id, g1.id)
+    await add_user_to_group(async_db_session, u2.id, g1.id)
+
+    # G1: u1 paid 100 USD for u1,u2 (50 each). u2 owes u1 50 USD.
+    # u2's share is partially settled by 20 USD.
+    await create_expense(async_db_session, "Big Dinner G1", 100.0, usd.id, u1.id, g1.id, participants_data=[
+        {"user_id": u1.id, "share_amount": 50.0},
+        {"user_id": u2.id, "share_amount": 50.0, "settled_amount": 20.0} # u2 owes 30 USD
+    ])
+
+    # G2: u2 paid 40 USD for u1,u2 (20 each). u1 owes u2 20 USD.
+    g2 = await create_group(async_db_session, "G2", u1.id, id=2)
+    await add_user_to_group(async_db_session, u1.id, g2.id)
+    await add_user_to_group(async_db_session, u2.id, g2.id)
+    await create_expense(async_db_session, "Small Lunch G2", 40.0, usd.id, u2.id, g2.id, participants_data=[
+        {"user_id": u1.id, "share_amount": 20.0}, # u1 owes 20 USD
+        {"user_id": u2.id, "share_amount": 20.0}
+    ])
+
+    # Overall:
+    # u1 is owed 30 USD by u2 (from G1).
+    # u1 owes 20 USD to u2 (from G2).
+    # Net: u1 is owed 10 USD by u2.
+
+    summary_u1 = await balance_service.calculate_user_overall_balances(u1.id, async_db_session)
+
+    assert summary_u1.total_owed_to_you_by_currency.get("USD", 0.0) == 30.0 # From G1 after settlement
+    assert summary_u1.total_you_owe_by_currency.get("USD", 0.0) == 20.0    # From G2
+    assert summary_u1.net_overall_balance_by_currency.get("USD", 0.0) == 10.0
+
+    assert len(summary_u1.detailed_credits_by_currency.get("USD", [])) == 1
+    assert summary_u1.detailed_credits_by_currency["USD"][0].owed_by_user_id == u2.id
+    assert summary_u1.detailed_credits_by_currency["USD"][0].amount == 10.0 # Net amount u2 owes u1
+
+    assert not summary_u1.detailed_debts_by_currency.get("USD")
+
+
+    summary_u2 = await balance_service.calculate_user_overall_balances(u2.id, session)
+    # u2 owes 30 USD to u1 (from G1 after settlement)
+    # u2 is owed 20 USD by u1 (from G2)
+    # Net: u2 owes 10 USD to u1
+    assert summary_u2.total_you_owe_by_currency.get("USD", 0.0) == 30.0
+    assert summary_u2.total_owed_to_you_by_currency.get("USD", 0.0) == 20.0
+    assert summary_u2.net_overall_balance_by_currency.get("USD", 0.0) == -10.0
+
+    assert len(summary_u2.detailed_debts_by_currency.get("USD", [])) == 1
+    assert summary_u2.detailed_debts_by_currency["USD"][0].owes_user_id == u1.id
+    assert summary_u2.detailed_debts_by_currency["USD"][0].amount == 10.0 # Net amount u2 owes u1
+    assert not summary_u2.detailed_credits_by_currency.get("USD")


### PR DESCRIPTION
- Define new schemas for balance representation (DebtDetail, CreditDetail, UserGroupBalance, GroupBalanceSummary, GroupBalanceUserPerspective, UserOverallBalance).
- Implement balance_service with functions to calculate group-specific and user-overall balances, handling multi-currency and settled expenses.
- Update GET /api/v1/balances/me to use the new service and response schema.
- Add new endpoint GET /api/v1/groups/{group_id}/balances.
- Add unit tests for balance_service.
- Update integration tests for API endpoints.
- Refactor test setup in conftest.py for better DB isolation using function-scoped engines and sessions.